### PR TITLE
WASM MVP: terminal renderer, PTY server, demo site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
  "tempfile",
  "toml",
  "toml_edit 0.24.0+spec-1.1.0",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
  "winit",
  "xdg",
@@ -94,6 +94,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "alacritty_pty_server"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "env_logger",
+ "futures-util",
+ "log",
+ "portable-pty",
+ "tokio",
+ "tokio-tungstenite",
+]
+
+[[package]]
 name = "alacritty_terminal"
 version = "0.25.2-dev"
 dependencies = [
@@ -112,9 +125,26 @@ dependencies = [
  "serde",
  "serde_json",
  "signal-hook",
- "unicode-width",
+ "unicode-width 0.2.2",
  "vte",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "alacritty_web"
+version = "0.1.0"
+dependencies = [
+ "alacritty_terminal",
+ "bytemuck",
+ "console_error_panic_hook",
+ "console_log",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+ "wgpu",
 ]
 
 [[package]]
@@ -133,7 +163,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -143,6 +173,15 @@ name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -195,6 +234,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,16 +258,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -237,6 +312,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -259,6 +349,20 @@ name = "bytemuck"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytes"
@@ -390,6 +494,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +526,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
 ]
 
 [[package]]
@@ -481,6 +615,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cstr"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +688,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -555,7 +724,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -581,6 +750,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -623,7 +801,30 @@ dependencies = [
  "rustc_version",
  "toml",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
+]
+
+[[package]]
+name = "env_filter"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -639,7 +840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -664,6 +865,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +890,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -738,10 +956,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "gethostname"
@@ -785,6 +1056,18 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -842,6 +1125,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.9.4",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.9.4",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,6 +1203,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
 name = "home"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,13 +1218,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "indexmap"
 version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -899,6 +1264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +1283,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jni"
@@ -950,6 +1348,17 @@ checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1024,6 +1433,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,6 +1478,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.9.4",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -1084,7 +1542,29 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "naga"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.9.4",
+ "cfg_aliases",
+ "codespan-reporting",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "rustc-hash",
+ "spirv",
+ "strum",
+ "termcolor",
+ "thiserror 2.0.17",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1096,7 +1576,7 @@ dependencies = [
  "bitflags 2.9.4",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -1110,11 +1590,34 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
+
+[[package]]
+name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]
@@ -1142,6 +1645,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1673,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -1437,6 +1958,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1988,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1490,6 +2026,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
@@ -1536,6 +2078,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +2145,12 @@ checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
 
 [[package]]
 name = "quick-xml"
@@ -1576,6 +2175,41 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "raw-window-handle"
@@ -1613,6 +2247,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +2274,18 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1661,7 +2319,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1792,6 +2450,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,6 +2554,15 @@ name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -1880,6 +2616,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
+dependencies = [
+ "bitflags 2.9.4",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2651,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1912,7 +2695,25 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1978,6 +2779,46 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -2061,6 +2902,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,15 +2938,33 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8parse"
@@ -2237,6 +3119,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e381134e148c1062f965a42ed1f5ee933eef2927c3f70d1812158f711d39865"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "wayland-backend"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,6 +3272,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.9.4",
+ "cfg_aliases",
+ "document-features",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "24.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
+dependencies = [
+ "arrayvec",
+ "bit-vec",
+ "bitflags 2.9.4",
+ "cfg_aliases",
+ "document-features",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.17",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "24.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.9.4",
+ "block",
+ "bytemuck",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "rustc-hash",
+ "smallvec",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "24.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
+dependencies = [
+ "bitflags 2.9.4",
+ "js-sys",
+ "log",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,7 +3402,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2397,10 +3412,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2693,6 +3772,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ members = [
     "alacritty_terminal",
     "alacritty_config",
     "alacritty_config_derive",
+    "alacritty_pty_server",
+    "alacritty_web",
 ]
 resolver = "2"
 

--- a/alacritty_pty_server/Cargo.toml
+++ b/alacritty_pty_server/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "alacritty_pty_server"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+description = "WebSocket PTY server for Alacritty WASM port"
+
+[[bin]]
+name = "alacritty-pty-server"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+futures-util = { version = "0.3", features = ["sink"] }
+log = "0.4"
+env_logger = "0.11"
+portable-pty = "0.8"
+tokio = { version = "1", features = ["full"] }
+tokio-tungstenite = "0.26"

--- a/alacritty_pty_server/src/main.rs
+++ b/alacritty_pty_server/src/main.rs
@@ -1,0 +1,73 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use clap::Parser;
+use log::{error, info, warn};
+use tokio::net::TcpListener;
+
+mod protocol;
+mod session;
+
+/// WebSocket PTY server for Alacritty WASM port.
+#[derive(Parser, Debug, Clone)]
+#[command(name = "alacritty-pty-server", version, about)]
+pub struct Args {
+    /// Address to bind to.
+    #[arg(long, default_value = "127.0.0.1")]
+    bind: String,
+
+    /// Port to listen on.
+    #[arg(long, default_value_t = 7681)]
+    port: u16,
+
+    /// Shell command to spawn (defaults to $SHELL or /bin/sh).
+    #[arg(long)]
+    shell: Option<String>,
+
+    /// Optional shared-secret token for authentication.
+    /// When set, the client must send this token as its first WebSocket message.
+    #[arg(long)]
+    token: Option<String>,
+}
+
+impl Args {
+    pub fn shell(&self) -> String {
+        self.shell
+            .clone()
+            .or_else(|| std::env::var("SHELL").ok())
+            .unwrap_or_else(|| "/bin/sh".to_string())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args = Arc::new(Args::parse());
+    let addr: SocketAddr = format!("{}:{}", args.bind, args.port)
+        .parse()
+        .expect("Invalid bind address");
+
+    let listener = TcpListener::bind(&addr)
+        .await
+        .expect("Failed to bind TCP listener");
+
+    info!("Alacritty PTY server listening on ws://{}", addr);
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer)) => {
+                info!("New TCP connection from {}", peer);
+                let args = Arc::clone(&args);
+                tokio::spawn(async move {
+                    if let Err(e) = session::handle_connection(stream, peer, args).await {
+                        error!("Session error for {}: {}", peer, e);
+                    }
+                });
+            }
+            Err(e) => {
+                warn!("Failed to accept connection: {}", e);
+            }
+        }
+    }
+}

--- a/alacritty_pty_server/src/protocol.rs
+++ b/alacritty_pty_server/src/protocol.rs
@@ -1,0 +1,68 @@
+/// Binary protocol message types for WebSocket PTY communication.
+///
+/// Wire format:
+/// - `0x00` + bytes           = PTY data (bidirectional)
+/// - `0x01` + 4x u16 LE      = resize (client -> server): cols, rows, cell_w, cell_h
+/// - `0x02` + optional u8     = child exited (server -> client), with optional exit code
+
+pub const MSG_DATA: u8 = 0x00;
+pub const MSG_RESIZE: u8 = 0x01;
+pub const MSG_EXIT: u8 = 0x02;
+
+/// A parsed message from the client.
+#[derive(Debug)]
+pub enum ClientMessage {
+    /// PTY input data.
+    Data(Vec<u8>),
+    /// Resize request: (cols, rows, cell_width, cell_height).
+    Resize {
+        cols: u16,
+        rows: u16,
+        cell_w: u16,
+        cell_h: u16,
+    },
+}
+
+/// Parse a binary WebSocket message from the client.
+pub fn parse_client_message(data: &[u8]) -> Option<ClientMessage> {
+    if data.is_empty() {
+        return None;
+    }
+
+    match data[0] {
+        MSG_DATA => Some(ClientMessage::Data(data[1..].to_vec())),
+        MSG_RESIZE => {
+            if data.len() < 9 {
+                // Need 1 byte tag + 4 * 2 bytes = 9 bytes total.
+                return None;
+            }
+            let cols = u16::from_le_bytes([data[1], data[2]]);
+            let rows = u16::from_le_bytes([data[3], data[4]]);
+            let cell_w = u16::from_le_bytes([data[5], data[6]]);
+            let cell_h = u16::from_le_bytes([data[7], data[8]]);
+            Some(ClientMessage::Resize {
+                cols,
+                rows,
+                cell_w,
+                cell_h,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Build a PTY data message to send to the client.
+pub fn encode_data(payload: &[u8]) -> Vec<u8> {
+    let mut msg = Vec::with_capacity(1 + payload.len());
+    msg.push(MSG_DATA);
+    msg.extend_from_slice(payload);
+    msg
+}
+
+/// Build a child-exited message to send to the client.
+pub fn encode_exit(exit_code: Option<u8>) -> Vec<u8> {
+    match exit_code {
+        Some(code) => vec![MSG_EXIT, code],
+        None => vec![MSG_EXIT],
+    }
+}

--- a/alacritty_pty_server/src/session.rs
+++ b/alacritty_pty_server/src/session.rs
@@ -1,0 +1,240 @@
+use std::io::{Read, Write};
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures_util::{SinkExt, StreamExt};
+use log::{error, info, warn};
+use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::handshake::server::{Request, Response};
+use tokio_tungstenite::tungstenite::http;
+use tokio_tungstenite::tungstenite::protocol::Message;
+
+use crate::Args;
+use crate::protocol::{self, ClientMessage};
+
+/// Handle a single TCP connection: upgrade to WebSocket, optionally authenticate,
+/// spawn a PTY, and bridge I/O.
+pub async fn handle_connection(
+    stream: tokio::net::TcpStream,
+    peer: SocketAddr,
+    args: Arc<Args>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // WebSocket upgrade with CORS headers.
+    let ws_stream = tokio_tungstenite::accept_hdr_async(stream, |req: &Request, mut resp: Response| {
+        // Add CORS header for the demo website.
+        resp.headers_mut().insert(
+            http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            http::HeaderValue::from_static("*"),
+        );
+        let _ = req;
+        Ok(resp)
+    })
+    .await?;
+
+    info!("WebSocket connection established with {}", peer);
+
+    let (mut ws_sink, mut ws_stream) = ws_stream.split();
+
+    // Token authentication if configured.
+    if let Some(ref expected_token) = args.token {
+        info!("Waiting for auth token from {}", peer);
+        match ws_stream.next().await {
+            Some(Ok(Message::Text(token))) => {
+                if token.trim() != expected_token.as_str() {
+                    warn!("Auth failed from {}: invalid token", peer);
+                    let _ = ws_sink
+                        .send(Message::Close(None))
+                        .await;
+                    return Ok(());
+                }
+                info!("Auth succeeded for {}", peer);
+            }
+            _ => {
+                warn!("Auth failed from {}: expected text message with token", peer);
+                let _ = ws_sink
+                    .send(Message::Close(None))
+                    .await;
+                return Ok(());
+            }
+        }
+    }
+
+    // Spawn PTY.
+    let pty_system = NativePtySystem::default();
+    let pty_size = PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    };
+
+    let pair = pty_system
+        .openpty(pty_size)
+        .map_err(|e| format!("Failed to open PTY: {}", e))?;
+
+    let shell = args.shell();
+    let mut cmd = CommandBuilder::new(&shell);
+    cmd.env("TERM", "xterm-256color");
+
+    let mut child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("Failed to spawn shell '{}': {}", shell, e))?;
+
+    // Drop the slave side - the child has it.
+    drop(pair.slave);
+
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("Failed to clone PTY reader: {}", e))?;
+
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("Failed to take PTY writer: {}", e))?;
+
+    // Channel for sending messages to the WebSocket sink.
+    let (ws_tx, mut ws_rx) = mpsc::channel::<Message>(64);
+
+    // Task 1: Read from PTY and forward to WebSocket via channel.
+    let ws_tx_pty = ws_tx.clone();
+    let pty_read_handle = tokio::task::spawn_blocking(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let msg = protocol::encode_data(&buf[..n]);
+                    if ws_tx_pty.blocking_send(Message::Binary(msg.into())).is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    // EIO is expected when the child exits on Linux.
+                    if e.kind() != std::io::ErrorKind::Other {
+                        error!("PTY read error: {}", e);
+                    }
+                    break;
+                }
+            }
+        }
+    });
+
+    // Task 2: Forward channel messages to WebSocket sink.
+    let ws_write_handle = tokio::spawn(async move {
+        while let Some(msg) = ws_rx.recv().await {
+            if ws_sink.send(msg).await.is_err() {
+                break;
+            }
+        }
+        let _ = ws_sink.close().await;
+    });
+
+    // Task 3: Read from WebSocket and write to PTY / handle resize.
+    let master = pair.master;
+    let _ws_tx_client = ws_tx.clone();
+    let ws_read_handle = tokio::task::spawn({
+        let writer = Arc::new(std::sync::Mutex::new(writer));
+        let master = Arc::new(std::sync::Mutex::new(master));
+        async move {
+            while let Some(msg_result) = ws_stream.next().await {
+                match msg_result {
+                    Ok(Message::Binary(data)) => {
+                        if let Some(client_msg) = protocol::parse_client_message(&data) {
+                            match client_msg {
+                                ClientMessage::Data(payload) => {
+                                    let writer = Arc::clone(&writer);
+                                    let _ = tokio::task::spawn_blocking(move || {
+                                        let mut w = writer.lock().unwrap();
+                                        let _ = w.write_all(&payload);
+                                    })
+                                    .await;
+                                }
+                                ClientMessage::Resize {
+                                    cols,
+                                    rows,
+                                    cell_w,
+                                    cell_h,
+                                } => {
+                                    let master = Arc::clone(&master);
+                                    let _ = tokio::task::spawn_blocking(move || {
+                                        let m = master.lock().unwrap();
+                                        let size = PtySize {
+                                            rows,
+                                            cols,
+                                            pixel_width: cell_w,
+                                            pixel_height: cell_h,
+                                        };
+                                        if let Err(e) = m.resize(size) {
+                                            warn!("PTY resize failed: {}", e);
+                                        } else {
+                                            info!(
+                                                "PTY resized to {}x{} ({}x{} px)",
+                                                cols, rows, cell_w, cell_h
+                                            );
+                                        }
+                                    })
+                                    .await;
+                                }
+                            }
+                        }
+                    }
+                    Ok(Message::Close(_)) => {
+                        info!("Client {} sent close", peer);
+                        break;
+                    }
+                    Ok(_) => {
+                        // Ignore text, ping, pong - we only use binary.
+                    }
+                    Err(e) => {
+                        warn!("WebSocket read error from {}: {}", peer, e);
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    // Task 4: Wait for child to exit and send exit notification.
+    let ws_tx_exit = ws_tx.clone();
+    let child_wait_handle = tokio::task::spawn_blocking(move || {
+        let status = child.wait();
+        let exit_code = match status {
+            Ok(status) => {
+                if status.success() {
+                    Some(0u8)
+                } else {
+                    // portable-pty ExitStatus doesn't expose the raw code easily,
+                    // so we use 1 for failure.
+                    Some(1u8)
+                }
+            }
+            Err(_) => None,
+        };
+        info!("Child exited with code: {:?}", exit_code);
+        let msg = protocol::encode_exit(exit_code);
+        let _ = ws_tx_exit.blocking_send(Message::Binary(msg.into()));
+    });
+
+    // Wait for the child to exit or the WebSocket read to finish.
+    tokio::select! {
+        _ = child_wait_handle => {
+            info!("Child process exited for {}", peer);
+        }
+        _ = ws_read_handle => {
+            info!("WebSocket closed by client {}", peer);
+        }
+    }
+
+    // Clean up: wait briefly for remaining data to flush.
+    let _ = pty_read_handle.await;
+
+    // Drop the sender so the write task finishes.
+    drop(ws_tx);
+    let _ = ws_write_handle.await;
+
+    info!("Session ended for {}", peer);
+    Ok(())
+}

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -17,15 +17,17 @@ serde = ["dep:serde", "bitflags/serde", "vte/serde"]
 [dependencies]
 base64 = "0.22.0"
 bitflags = "2.4.1"
-home = "0.5.5"
-libc = "0.2"
 log = "0.4"
 parking_lot = "0.12.0"
-polling = "3.8.0"
 regex-automata = "0.4.3"
 unicode-width = "0.2.0"
 vte = { version = "0.15.0", default-features = false, features = ["std", "ansi"] }
 serde = { version = "1", features = ["derive", "rc"], optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+home = "0.5.5"
+libc = "0.2"
+polling = "3.8.0"
 
 [target.'cfg(unix)'.dependencies]
 rustix-openpty = "0.2.0"

--- a/alacritty_terminal/src/event.rs
+++ b/alacritty_terminal/src/event.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::{self, Debug, Formatter};
+#[cfg(not(target_arch = "wasm32"))]
 use std::process::ExitStatus;
 use std::sync::Arc;
 
@@ -55,6 +56,7 @@ pub enum Event {
     Exit,
 
     /// Child process exited.
+    #[cfg(not(target_arch = "wasm32"))]
     ChildExit(ExitStatus),
 }
 
@@ -73,6 +75,7 @@ impl Debug for Event {
             Event::Wakeup => write!(f, "Wakeup"),
             Event::Bell => write!(f, "Bell"),
             Event::Exit => write!(f, "Exit"),
+            #[cfg(not(target_arch = "wasm32"))]
             Event::ChildExit(status) => write!(f, "ChildExit({status:?})"),
         }
     }

--- a/alacritty_terminal/src/event_loop.rs
+++ b/alacritty_terminal/src/event_loop.rs
@@ -1,30 +1,8 @@
 //! The main event loop which performs I/O on the pseudoterminal.
 
 use std::borrow::Cow;
-use std::collections::VecDeque;
-use std::fmt::{self, Display, Formatter};
-use std::fs::File;
-use std::io::{self, ErrorKind, Read, Write};
-use std::num::NonZeroUsize;
-use std::sync::Arc;
-use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
-use std::thread::JoinHandle;
-use std::time::Instant;
 
-use log::error;
-use polling::{Event as PollingEvent, Events, PollMode, Poller};
-
-use crate::event::{self, Event, EventListener, WindowSize};
-use crate::sync::FairMutex;
-use crate::term::Term;
-use crate::{thread, tty};
-use vte::ansi;
-
-/// Max bytes to read from the PTY before forced terminal synchronization.
-pub(crate) const READ_BUFFER_SIZE: usize = 0x10_0000;
-
-/// Max bytes to read from the PTY while the terminal is locked.
-const MAX_LOCKED_READ: usize = u16::MAX as usize;
+use crate::event::WindowSize;
 
 /// Messages that may be sent to the `EventLoop`.
 #[derive(Debug)]
@@ -39,448 +17,492 @@ pub enum Msg {
     Resize(WindowSize),
 }
 
-/// The main event loop.
-///
-/// Handles all the PTY I/O and runs the PTY parser which updates terminal
-/// state.
-pub struct EventLoop<T: tty::EventedPty, U: EventListener> {
-    poll: Arc<Poller>,
-    pty: T,
-    rx: PeekableReceiver<Msg>,
-    tx: Sender<Msg>,
-    terminal: Arc<FairMutex<Term<U>>>,
-    event_proxy: U,
-    drain_on_exit: bool,
-    ref_test: bool,
-}
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::borrow::Cow;
+    use std::collections::VecDeque;
+    use std::fmt::{self, Display, Formatter};
+    use std::fs::File;
+    use std::io::{self, ErrorKind, Read, Write};
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+    use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
+    use std::thread::JoinHandle;
+    use std::time::Instant;
 
-impl<T, U> EventLoop<T, U>
-where
-    T: tty::EventedPty + event::OnResize + Send + 'static,
-    U: EventListener + Send + 'static,
-{
-    /// Create a new event loop.
-    pub fn new(
+    use log::error;
+    use polling::{Event as PollingEvent, Events, PollMode, Poller};
+
+    use crate::event::{self, Event, EventListener, WindowSize};
+    use crate::sync::FairMutex;
+    use crate::term::Term;
+    use crate::{thread, tty};
+    use vte::ansi;
+
+    use super::Msg;
+
+    /// Max bytes to read from the PTY before forced terminal synchronization.
+    pub(crate) const READ_BUFFER_SIZE: usize = 0x10_0000;
+
+    /// Max bytes to read from the PTY while the terminal is locked.
+    const MAX_LOCKED_READ: usize = u16::MAX as usize;
+
+    /// The main event loop.
+    ///
+    /// Handles all the PTY I/O and runs the PTY parser which updates terminal
+    /// state.
+    pub struct EventLoop<T: tty::EventedPty, U: EventListener> {
+        poll: Arc<Poller>,
+        pty: T,
+        rx: PeekableReceiver<Msg>,
+        tx: Sender<Msg>,
         terminal: Arc<FairMutex<Term<U>>>,
         event_proxy: U,
-        pty: T,
         drain_on_exit: bool,
         ref_test: bool,
-    ) -> io::Result<EventLoop<T, U>> {
-        let (tx, rx) = mpsc::channel();
-        let poll = Poller::new()?.into();
-        Ok(EventLoop {
-            poll,
-            pty,
-            tx,
-            rx: PeekableReceiver::new(rx),
-            terminal,
-            event_proxy,
-            drain_on_exit,
-            ref_test,
-        })
     }
 
-    pub fn channel(&self) -> EventLoopSender {
-        EventLoopSender { sender: self.tx.clone(), poller: self.poll.clone() }
-    }
-
-    /// Drain the channel.
-    ///
-    /// Returns `false` when a shutdown message was received.
-    fn drain_recv_channel(&mut self, state: &mut State) -> bool {
-        while let Some(msg) = self.rx.recv() {
-            match msg {
-                Msg::Input(input) => state.write_list.push_back(input),
-                Msg::Resize(window_size) => self.pty.on_resize(window_size),
-                Msg::Shutdown => return false,
-            }
-        }
-
-        true
-    }
-
-    #[inline]
-    fn pty_read<X>(
-        &mut self,
-        state: &mut State,
-        buf: &mut [u8],
-        mut writer: Option<&mut X>,
-    ) -> io::Result<()>
+    impl<T, U> EventLoop<T, U>
     where
-        X: Write,
+        T: tty::EventedPty + event::OnResize + Send + 'static,
+        U: EventListener + Send + 'static,
     {
-        let mut unprocessed = 0;
-        let mut processed = 0;
-
-        // Reserve the next terminal lock for PTY reading.
-        let _terminal_lease = Some(self.terminal.lease());
-        let mut terminal = None;
-
-        loop {
-            // Read from the PTY.
-            match self.pty.reader().read(&mut buf[unprocessed..]) {
-                // This is received on Windows/macOS when no more data is readable from the PTY.
-                Ok(0) if unprocessed == 0 => break,
-                Ok(got) => unprocessed += got,
-                Err(err) => match err.kind() {
-                    ErrorKind::Interrupted | ErrorKind::WouldBlock => {
-                        // Go back to mio if we're caught up on parsing and the PTY would block.
-                        if unprocessed == 0 {
-                            break;
-                        }
-                    },
-                    _ => return Err(err),
-                },
-            }
-
-            // Attempt to lock the terminal.
-            let terminal = match &mut terminal {
-                Some(terminal) => terminal,
-                None => terminal.insert(match self.terminal.try_lock_unfair() {
-                    // Force block if we are at the buffer size limit.
-                    None if unprocessed >= READ_BUFFER_SIZE => self.terminal.lock_unfair(),
-                    None => continue,
-                    Some(terminal) => terminal,
-                }),
-            };
-
-            // Write a copy of the bytes to the ref test file.
-            if let Some(writer) = &mut writer {
-                writer.write_all(&buf[..unprocessed]).unwrap();
-            }
-
-            // Parse the incoming bytes.
-            state.parser.advance(&mut **terminal, &buf[..unprocessed]);
-
-            processed += unprocessed;
-            unprocessed = 0;
-
-            // Assure we're not blocking the terminal too long unnecessarily.
-            if processed >= MAX_LOCKED_READ {
-                break;
-            }
+        /// Create a new event loop.
+        pub fn new(
+            terminal: Arc<FairMutex<Term<U>>>,
+            event_proxy: U,
+            pty: T,
+            drain_on_exit: bool,
+            ref_test: bool,
+        ) -> io::Result<EventLoop<T, U>> {
+            let (tx, rx) = mpsc::channel();
+            let poll = Poller::new()?.into();
+            Ok(EventLoop {
+                poll,
+                pty,
+                tx,
+                rx: PeekableReceiver::new(rx),
+                terminal,
+                event_proxy,
+                drain_on_exit,
+                ref_test,
+            })
         }
 
-        // Queue terminal redraw unless all processed bytes were synchronized.
-        if state.parser.sync_bytes_count() < processed && processed > 0 {
-            self.event_proxy.send_event(Event::Wakeup);
+        pub fn channel(&self) -> EventLoopSender {
+            EventLoopSender { sender: self.tx.clone(), poller: self.poll.clone() }
         }
 
-        Ok(())
-    }
-
-    #[inline]
-    fn pty_write(&mut self, state: &mut State) -> io::Result<()> {
-        state.ensure_next();
-
-        'write_many: while let Some(mut current) = state.take_current() {
-            'write_one: loop {
-                match self.pty.writer().write(current.remaining_bytes()) {
-                    Ok(0) => {
-                        state.set_current(Some(current));
-                        break 'write_many;
-                    },
-                    Ok(n) => {
-                        current.advance(n);
-                        if current.finished() {
-                            state.goto_next();
-                            break 'write_one;
-                        }
-                    },
-                    Err(err) => {
-                        state.set_current(Some(current));
-                        match err.kind() {
-                            ErrorKind::Interrupted | ErrorKind::WouldBlock => break 'write_many,
-                            _ => return Err(err),
-                        }
-                    },
+        /// Drain the channel.
+        ///
+        /// Returns `false` when a shutdown message was received.
+        fn drain_recv_channel(&mut self, state: &mut State) -> bool {
+            while let Some(msg) = self.rx.recv() {
+                match msg {
+                    Msg::Input(input) => state.write_list.push_back(input),
+                    Msg::Resize(window_size) => self.pty.on_resize(window_size),
+                    Msg::Shutdown => return false,
                 }
             }
+
+            true
         }
 
-        Ok(())
-    }
+        #[inline]
+        fn pty_read<X>(
+            &mut self,
+            state: &mut State,
+            buf: &mut [u8],
+            mut writer: Option<&mut X>,
+        ) -> io::Result<()>
+        where
+            X: Write,
+        {
+            let mut unprocessed = 0;
+            let mut processed = 0;
 
-    pub fn spawn(mut self) -> JoinHandle<(Self, State)> {
-        thread::spawn_named("PTY reader", move || {
-            let mut state = State::default();
-            let mut buf = [0u8; READ_BUFFER_SIZE];
+            // Reserve the next terminal lock for PTY reading.
+            let _terminal_lease = Some(self.terminal.lease());
+            let mut terminal = None;
 
-            let poll_opts = PollMode::Level;
-            let mut interest = PollingEvent::readable(0);
-
-            // Register TTY through EventedRW interface.
-            if let Err(err) = unsafe { self.pty.register(&self.poll, interest, poll_opts) } {
-                error!("Event loop registration error: {err}");
-                return (self, state);
-            }
-
-            let mut events = Events::with_capacity(NonZeroUsize::new(1024).unwrap());
-
-            let mut pipe = if self.ref_test {
-                Some(File::create("./alacritty.recording").expect("create alacritty recording"))
-            } else {
-                None
-            };
-
-            'event_loop: loop {
-                // Wakeup the event loop when a synchronized update timeout was reached.
-                let handler = state.parser.sync_timeout();
-                let timeout =
-                    handler.sync_timeout().map(|st| st.saturating_duration_since(Instant::now()));
-
-                events.clear();
-                if let Err(err) = self.poll.wait(&mut events, timeout) {
-                    match err.kind() {
-                        ErrorKind::Interrupted => continue,
-                        _ => {
-                            error!("Event loop polling error: {err}");
-                            break 'event_loop;
+            loop {
+                // Read from the PTY.
+                match self.pty.reader().read(&mut buf[unprocessed..]) {
+                    // This is received on Windows/macOS when no more data is readable from the
+                    // PTY.
+                    Ok(0) if unprocessed == 0 => break,
+                    Ok(got) => unprocessed += got,
+                    Err(err) => match err.kind() {
+                        ErrorKind::Interrupted | ErrorKind::WouldBlock => {
+                            // Go back to mio if we're caught up on parsing and the PTY would
+                            // block.
+                            if unprocessed == 0 {
+                                break;
+                            }
                         },
-                    }
+                        _ => return Err(err),
+                    },
                 }
 
-                // Handle synchronized update timeout.
-                if events.is_empty() && self.rx.peek().is_none() {
-                    state.parser.stop_sync(&mut *self.terminal.lock());
-                    self.event_proxy.send_event(Event::Wakeup);
-                    continue;
+                // Attempt to lock the terminal.
+                let terminal = match &mut terminal {
+                    Some(terminal) => terminal,
+                    None => terminal.insert(match self.terminal.try_lock_unfair() {
+                        // Force block if we are at the buffer size limit.
+                        None if unprocessed >= READ_BUFFER_SIZE => self.terminal.lock_unfair(),
+                        None => continue,
+                        Some(terminal) => terminal,
+                    }),
+                };
+
+                // Write a copy of the bytes to the ref test file.
+                if let Some(writer) = &mut writer {
+                    writer.write_all(&buf[..unprocessed]).unwrap();
                 }
 
-                // Handle channel events, if there are any.
-                if !self.drain_recv_channel(&mut state) {
+                // Parse the incoming bytes.
+                state.parser.advance(&mut **terminal, &buf[..unprocessed]);
+
+                processed += unprocessed;
+                unprocessed = 0;
+
+                // Assure we're not blocking the terminal too long unnecessarily.
+                if processed >= MAX_LOCKED_READ {
                     break;
                 }
+            }
 
-                for event in events.iter() {
-                    match event.key {
-                        tty::PTY_CHILD_EVENT_TOKEN => {
-                            if let Some(tty::ChildEvent::Exited(status)) =
-                                self.pty.next_child_event()
-                            {
-                                if let Some(status) = status {
-                                    self.event_proxy.send_event(Event::ChildExit(status));
-                                }
-                                if self.drain_on_exit {
-                                    let _ = self.pty_read(&mut state, &mut buf, pipe.as_mut());
-                                }
-                                self.terminal.lock().exit();
-                                self.event_proxy.send_event(Event::Wakeup);
+            // Queue terminal redraw unless all processed bytes were synchronized.
+            if state.parser.sync_bytes_count() < processed && processed > 0 {
+                self.event_proxy.send_event(Event::Wakeup);
+            }
+
+            Ok(())
+        }
+
+        #[inline]
+        fn pty_write(&mut self, state: &mut State) -> io::Result<()> {
+            state.ensure_next();
+
+            'write_many: while let Some(mut current) = state.take_current() {
+                'write_one: loop {
+                    match self.pty.writer().write(current.remaining_bytes()) {
+                        Ok(0) => {
+                            state.set_current(Some(current));
+                            break 'write_many;
+                        },
+                        Ok(n) => {
+                            current.advance(n);
+                            if current.finished() {
+                                state.goto_next();
+                                break 'write_one;
+                            }
+                        },
+                        Err(err) => {
+                            state.set_current(Some(current));
+                            match err.kind() {
+                                ErrorKind::Interrupted | ErrorKind::WouldBlock => {
+                                    break 'write_many
+                                },
+                                _ => return Err(err),
+                            }
+                        },
+                    }
+                }
+            }
+
+            Ok(())
+        }
+
+        pub fn spawn(mut self) -> JoinHandle<(Self, State)> {
+            thread::spawn_named("PTY reader", move || {
+                let mut state = State::default();
+                let mut buf = [0u8; READ_BUFFER_SIZE];
+
+                let poll_opts = PollMode::Level;
+                let mut interest = PollingEvent::readable(0);
+
+                // Register TTY through EventedRW interface.
+                if let Err(err) = unsafe { self.pty.register(&self.poll, interest, poll_opts) } {
+                    error!("Event loop registration error: {err}");
+                    return (self, state);
+                }
+
+                let mut events = Events::with_capacity(NonZeroUsize::new(1024).unwrap());
+
+                let mut pipe = if self.ref_test {
+                    Some(
+                        File::create("./alacritty.recording")
+                            .expect("create alacritty recording"),
+                    )
+                } else {
+                    None
+                };
+
+                'event_loop: loop {
+                    // Wakeup the event loop when a synchronized update timeout was reached.
+                    let handler = state.parser.sync_timeout();
+                    let timeout = handler
+                        .sync_timeout()
+                        .map(|st| st.saturating_duration_since(Instant::now()));
+
+                    events.clear();
+                    if let Err(err) = self.poll.wait(&mut events, timeout) {
+                        match err.kind() {
+                            ErrorKind::Interrupted => continue,
+                            _ => {
+                                error!("Event loop polling error: {err}");
                                 break 'event_loop;
-                            }
-                        },
+                            },
+                        }
+                    }
 
-                        tty::PTY_READ_WRITE_TOKEN => {
-                            if event.is_interrupt() {
-                                // Don't try to do I/O on a dead PTY.
-                                continue;
-                            }
+                    // Handle synchronized update timeout.
+                    if events.is_empty() && self.rx.peek().is_none() {
+                        state.parser.stop_sync(&mut *self.terminal.lock());
+                        self.event_proxy.send_event(Event::Wakeup);
+                        continue;
+                    }
 
-                            if event.readable {
-                                if let Err(err) = self.pty_read(&mut state, &mut buf, pipe.as_mut())
+                    // Handle channel events, if there are any.
+                    if !self.drain_recv_channel(&mut state) {
+                        break;
+                    }
+
+                    for event in events.iter() {
+                        match event.key {
+                            tty::PTY_CHILD_EVENT_TOKEN => {
+                                if let Some(tty::ChildEvent::Exited(status)) =
+                                    self.pty.next_child_event()
                                 {
-                                    // On Linux, a `read` on the master side of a PTY can fail
-                                    // with `EIO` if the client side hangs up.  In that case,
-                                    // just loop back round for the inevitable `Exited` event.
-                                    // This sucks, but checking the process is either racy or
-                                    // blocking.
-                                    #[cfg(target_os = "linux")]
-                                    if err.raw_os_error() == Some(libc::EIO) {
-                                        continue;
+                                    if let Some(status) = status {
+                                        self.event_proxy.send_event(Event::ChildExit(status));
                                     }
-
-                                    error!("Error reading from PTY in event loop: {err}");
+                                    if self.drain_on_exit {
+                                        let _ =
+                                            self.pty_read(&mut state, &mut buf, pipe.as_mut());
+                                    }
+                                    self.terminal.lock().exit();
+                                    self.event_proxy.send_event(Event::Wakeup);
                                     break 'event_loop;
                                 }
-                            }
+                            },
 
-                            if event.writable {
-                                if let Err(err) = self.pty_write(&mut state) {
-                                    error!("Error writing to PTY in event loop: {err}");
-                                    break 'event_loop;
+                            tty::PTY_READ_WRITE_TOKEN => {
+                                if event.is_interrupt() {
+                                    // Don't try to do I/O on a dead PTY.
+                                    continue;
                                 }
-                            }
-                        },
-                        _ => (),
+
+                                if event.readable {
+                                    if let Err(err) =
+                                        self.pty_read(&mut state, &mut buf, pipe.as_mut())
+                                    {
+                                        // On Linux, a `read` on the master side of a PTY can fail
+                                        // with `EIO` if the client side hangs up.  In that case,
+                                        // just loop back round for the inevitable `Exited` event.
+                                        // This sucks, but checking the process is either racy or
+                                        // blocking.
+                                        #[cfg(target_os = "linux")]
+                                        if err.raw_os_error() == Some(libc::EIO) {
+                                            continue;
+                                        }
+
+                                        error!("Error reading from PTY in event loop: {err}");
+                                        break 'event_loop;
+                                    }
+                                }
+
+                                if event.writable {
+                                    if let Err(err) = self.pty_write(&mut state) {
+                                        error!("Error writing to PTY in event loop: {err}");
+                                        break 'event_loop;
+                                    }
+                                }
+                            },
+                            _ => (),
+                        }
+                    }
+
+                    // Register write interest if necessary.
+                    let needs_write = state.needs_write();
+                    if needs_write != interest.writable {
+                        interest.writable = needs_write;
+
+                        // Re-register with new interest.
+                        self.pty.reregister(&self.poll, interest, poll_opts).unwrap();
                     }
                 }
 
-                // Register write interest if necessary.
-                let needs_write = state.needs_write();
-                if needs_write != interest.writable {
-                    interest.writable = needs_write;
+                // The evented instances are not dropped here so deregister them explicitly.
+                let _ = self.pty.deregister(&self.poll);
 
-                    // Re-register with new interest.
-                    self.pty.reregister(&self.poll, interest, poll_opts).unwrap();
+                (self, state)
+            })
+        }
+    }
+
+    /// Helper type which tracks how much of a buffer has been written.
+    struct Writing {
+        source: Cow<'static, [u8]>,
+        written: usize,
+    }
+
+    pub struct Notifier(pub EventLoopSender);
+
+    impl event::Notify for Notifier {
+        fn notify<B>(&self, bytes: B)
+        where
+            B: Into<Cow<'static, [u8]>>,
+        {
+            let bytes = bytes.into();
+            // Terminal hangs if we send 0 bytes through.
+            if bytes.is_empty() {
+                return;
+            }
+
+            let _ = self.0.send(Msg::Input(bytes));
+        }
+    }
+
+    impl event::OnResize for Notifier {
+        fn on_resize(&mut self, window_size: WindowSize) {
+            let _ = self.0.send(Msg::Resize(window_size));
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum EventLoopSendError {
+        /// Error polling the event loop.
+        Io(io::Error),
+
+        /// Error sending a message to the event loop.
+        Send(mpsc::SendError<Msg>),
+    }
+
+    impl Display for EventLoopSendError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            match self {
+                EventLoopSendError::Io(err) => err.fmt(f),
+                EventLoopSendError::Send(err) => err.fmt(f),
+            }
+        }
+    }
+
+    impl std::error::Error for EventLoopSendError {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            match self {
+                EventLoopSendError::Io(err) => err.source(),
+                EventLoopSendError::Send(err) => err.source(),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct EventLoopSender {
+        sender: Sender<Msg>,
+        poller: Arc<Poller>,
+    }
+
+    impl EventLoopSender {
+        pub fn send(&self, msg: Msg) -> Result<(), EventLoopSendError> {
+            self.sender.send(msg).map_err(EventLoopSendError::Send)?;
+            self.poller.notify().map_err(EventLoopSendError::Io)
+        }
+    }
+
+    /// All of the mutable state needed to run the event loop.
+    ///
+    /// Contains list of items to write, current write state, etc. Anything that
+    /// would otherwise be mutated on the `EventLoop` goes here.
+    #[derive(Default)]
+    pub struct State {
+        write_list: VecDeque<Cow<'static, [u8]>>,
+        writing: Option<Writing>,
+        parser: ansi::Processor,
+    }
+
+    impl State {
+        #[inline]
+        fn ensure_next(&mut self) {
+            if self.writing.is_none() {
+                self.goto_next();
+            }
+        }
+
+        #[inline]
+        fn goto_next(&mut self) {
+            self.writing = self.write_list.pop_front().map(Writing::new);
+        }
+
+        #[inline]
+        fn take_current(&mut self) -> Option<Writing> {
+            self.writing.take()
+        }
+
+        #[inline]
+        fn needs_write(&self) -> bool {
+            self.writing.is_some() || !self.write_list.is_empty()
+        }
+
+        #[inline]
+        fn set_current(&mut self, new: Option<Writing>) {
+            self.writing = new;
+        }
+    }
+
+    impl Writing {
+        #[inline]
+        fn new(c: Cow<'static, [u8]>) -> Writing {
+            Writing { source: c, written: 0 }
+        }
+
+        #[inline]
+        fn advance(&mut self, n: usize) {
+            self.written += n;
+        }
+
+        #[inline]
+        fn remaining_bytes(&self) -> &[u8] {
+            &self.source[self.written..]
+        }
+
+        #[inline]
+        fn finished(&self) -> bool {
+            self.written >= self.source.len()
+        }
+    }
+
+    struct PeekableReceiver<T> {
+        rx: Receiver<T>,
+        peeked: Option<T>,
+    }
+
+    impl<T> PeekableReceiver<T> {
+        fn new(rx: Receiver<T>) -> Self {
+            Self { rx, peeked: None }
+        }
+
+        fn peek(&mut self) -> Option<&T> {
+            if self.peeked.is_none() {
+                self.peeked = self.rx.try_recv().ok();
+            }
+
+            self.peeked.as_ref()
+        }
+
+        fn recv(&mut self) -> Option<T> {
+            if self.peeked.is_some() {
+                self.peeked.take()
+            } else {
+                match self.rx.try_recv() {
+                    Err(TryRecvError::Disconnected) => panic!("event loop channel closed"),
+                    res => res.ok(),
                 }
             }
-
-            // The evented instances are not dropped here so deregister them explicitly.
-            let _ = self.pty.deregister(&self.poll);
-
-            (self, state)
-        })
-    }
-}
-
-/// Helper type which tracks how much of a buffer has been written.
-struct Writing {
-    source: Cow<'static, [u8]>,
-    written: usize,
-}
-
-pub struct Notifier(pub EventLoopSender);
-
-impl event::Notify for Notifier {
-    fn notify<B>(&self, bytes: B)
-    where
-        B: Into<Cow<'static, [u8]>>,
-    {
-        let bytes = bytes.into();
-        // Terminal hangs if we send 0 bytes through.
-        if bytes.is_empty() {
-            return;
-        }
-
-        let _ = self.0.send(Msg::Input(bytes));
-    }
-}
-
-impl event::OnResize for Notifier {
-    fn on_resize(&mut self, window_size: WindowSize) {
-        let _ = self.0.send(Msg::Resize(window_size));
-    }
-}
-
-#[derive(Debug)]
-pub enum EventLoopSendError {
-    /// Error polling the event loop.
-    Io(io::Error),
-
-    /// Error sending a message to the event loop.
-    Send(mpsc::SendError<Msg>),
-}
-
-impl Display for EventLoopSendError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            EventLoopSendError::Io(err) => err.fmt(f),
-            EventLoopSendError::Send(err) => err.fmt(f),
         }
     }
 }
 
-impl std::error::Error for EventLoopSendError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            EventLoopSendError::Io(err) => err.source(),
-            EventLoopSendError::Send(err) => err.source(),
-        }
-    }
-}
-
-#[derive(Clone)]
-pub struct EventLoopSender {
-    sender: Sender<Msg>,
-    poller: Arc<Poller>,
-}
-
-impl EventLoopSender {
-    pub fn send(&self, msg: Msg) -> Result<(), EventLoopSendError> {
-        self.sender.send(msg).map_err(EventLoopSendError::Send)?;
-        self.poller.notify().map_err(EventLoopSendError::Io)
-    }
-}
-
-/// All of the mutable state needed to run the event loop.
-///
-/// Contains list of items to write, current write state, etc. Anything that
-/// would otherwise be mutated on the `EventLoop` goes here.
-#[derive(Default)]
-pub struct State {
-    write_list: VecDeque<Cow<'static, [u8]>>,
-    writing: Option<Writing>,
-    parser: ansi::Processor,
-}
-
-impl State {
-    #[inline]
-    fn ensure_next(&mut self) {
-        if self.writing.is_none() {
-            self.goto_next();
-        }
-    }
-
-    #[inline]
-    fn goto_next(&mut self) {
-        self.writing = self.write_list.pop_front().map(Writing::new);
-    }
-
-    #[inline]
-    fn take_current(&mut self) -> Option<Writing> {
-        self.writing.take()
-    }
-
-    #[inline]
-    fn needs_write(&self) -> bool {
-        self.writing.is_some() || !self.write_list.is_empty()
-    }
-
-    #[inline]
-    fn set_current(&mut self, new: Option<Writing>) {
-        self.writing = new;
-    }
-}
-
-impl Writing {
-    #[inline]
-    fn new(c: Cow<'static, [u8]>) -> Writing {
-        Writing { source: c, written: 0 }
-    }
-
-    #[inline]
-    fn advance(&mut self, n: usize) {
-        self.written += n;
-    }
-
-    #[inline]
-    fn remaining_bytes(&self) -> &[u8] {
-        &self.source[self.written..]
-    }
-
-    #[inline]
-    fn finished(&self) -> bool {
-        self.written >= self.source.len()
-    }
-}
-
-struct PeekableReceiver<T> {
-    rx: Receiver<T>,
-    peeked: Option<T>,
-}
-
-impl<T> PeekableReceiver<T> {
-    fn new(rx: Receiver<T>) -> Self {
-        Self { rx, peeked: None }
-    }
-
-    fn peek(&mut self) -> Option<&T> {
-        if self.peeked.is_none() {
-            self.peeked = self.rx.try_recv().ok();
-        }
-
-        self.peeked.as_ref()
-    }
-
-    fn recv(&mut self) -> Option<T> {
-        if self.peeked.is_some() {
-            self.peeked.take()
-        } else {
-            match self.rx.try_recv() {
-                Err(TryRecvError::Disconnected) => panic!("event loop channel closed"),
-                res => res.ok(),
-            }
-        }
-    }
-}
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::native::*;

--- a/alacritty_terminal/src/sync.rs
+++ b/alacritty_terminal/src/sync.rs
@@ -2,48 +2,81 @@
 //!
 //! Most importantly, a fair mutex is included.
 
-use parking_lot::{Mutex, MutexGuard};
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use parking_lot::{Mutex, MutexGuard};
 
-/// A fair mutex.
-///
-/// Uses an extra lock to ensure that if one thread is waiting that it will get
-/// the lock before a single thread can re-lock it.
-pub struct FairMutex<T> {
-    /// Data.
-    data: Mutex<T>,
-    /// Next-to-access.
-    next: Mutex<()>,
-}
-
-impl<T> FairMutex<T> {
-    /// Create a new fair mutex.
-    pub fn new(data: T) -> FairMutex<T> {
-        FairMutex { data: Mutex::new(data), next: Mutex::new(()) }
-    }
-
-    /// Acquire a lease to reserve the mutex lock.
+    /// A fair mutex.
     ///
-    /// This will prevent others from acquiring a terminal lock, but block if anyone else is
-    /// already holding a lease.
-    pub fn lease(&self) -> MutexGuard<'_, ()> {
-        self.next.lock()
+    /// Uses an extra lock to ensure that if one thread is waiting that it will get
+    /// the lock before a single thread can re-lock it.
+    pub struct FairMutex<T> {
+        /// Data.
+        data: Mutex<T>,
+        /// Next-to-access.
+        next: Mutex<()>,
     }
 
-    /// Lock the mutex.
-    pub fn lock(&self) -> MutexGuard<'_, T> {
-        // Must bind to a temporary or the lock will be freed before going
-        // into data.lock().
-        let _next = self.next.lock();
-        self.data.lock()
-    }
+    impl<T> FairMutex<T> {
+        /// Create a new fair mutex.
+        pub fn new(data: T) -> FairMutex<T> {
+            FairMutex { data: Mutex::new(data), next: Mutex::new(()) }
+        }
 
-    /// Unfairly lock the mutex.
-    pub fn lock_unfair(&self) -> MutexGuard<'_, T> {
-        self.data.lock()
-    }
+        /// Acquire a lease to reserve the mutex lock.
+        ///
+        /// This will prevent others from acquiring a terminal lock, but block if anyone else is
+        /// already holding a lease.
+        pub fn lease(&self) -> MutexGuard<'_, ()> {
+            self.next.lock()
+        }
 
-    /// Unfairly try to lock the mutex.
-    pub fn try_lock_unfair(&self) -> Option<MutexGuard<'_, T>> {
-        self.data.try_lock()
+        /// Lock the mutex.
+        pub fn lock(&self) -> MutexGuard<'_, T> {
+            // Must bind to a temporary or the lock will be freed before going
+            // into data.lock().
+            let _next = self.next.lock();
+            self.data.lock()
+        }
+
+        /// Unfairly lock the mutex.
+        pub fn lock_unfair(&self) -> MutexGuard<'_, T> {
+            self.data.lock()
+        }
+
+        /// Unfairly try to lock the mutex.
+        pub fn try_lock_unfair(&self) -> Option<MutexGuard<'_, T>> {
+            self.data.try_lock()
+        }
     }
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::native::FairMutex;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use std::cell::{RefCell, RefMut};
+
+    /// A single-threaded "mutex" for WASM using RefCell.
+    ///
+    /// On WASM, there is only one thread, so a RefCell suffices.
+    pub struct FairMutex<T> {
+        data: RefCell<T>,
+    }
+
+    impl<T> FairMutex<T> {
+        /// Create a new fair mutex.
+        pub fn new(data: T) -> FairMutex<T> {
+            FairMutex { data: RefCell::new(data) }
+        }
+
+        /// Lock the mutex (mutably borrow the data).
+        pub fn lock(&self) -> RefMut<'_, T> {
+            self.data.borrow_mut()
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use self::wasm::FairMutex;

--- a/alacritty_terminal/src/thread.rs
+++ b/alacritty_terminal/src/thread.rs
@@ -1,6 +1,8 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::thread::{Builder, JoinHandle};
 
 /// Like `thread::spawn`, but with a `name` argument.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn spawn_named<F, T, S>(name: S, f: F) -> JoinHandle<T>
 where
     F: FnOnce() -> T + Send + 'static,

--- a/alacritty_terminal/src/tty/mod.rs
+++ b/alacritty_terminal/src/tty/mod.rs
@@ -2,20 +2,25 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::process::ExitStatus;
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::{env, io};
 
+#[cfg(not(target_arch = "wasm32"))]
 use polling::{Event, PollMode, Poller};
 
-#[cfg(not(windows))]
+#[cfg(all(not(target_arch = "wasm32"), not(windows)))]
 mod unix;
-#[cfg(not(windows))]
+#[cfg(all(not(target_arch = "wasm32"), not(windows)))]
 pub use self::unix::*;
 
-#[cfg(windows)]
+#[cfg(all(not(target_arch = "wasm32"), windows))]
 pub mod windows;
-#[cfg(windows)]
+#[cfg(all(not(target_arch = "wasm32"), windows))]
 pub use self::windows::*;
 
 /// Configuration for the `Pty` interface.
@@ -62,6 +67,7 @@ impl Shell {
 ///
 /// This defines an abstraction over polling's interface in order to allow either
 /// one read/write object or a separate read and write object.
+#[cfg(not(target_arch = "wasm32"))]
 pub trait EventedReadWrite {
     type Reader: io::Read;
     type Writer: io::Write;
@@ -78,6 +84,7 @@ pub trait EventedReadWrite {
 }
 
 /// Events concerning TTY child processes.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, PartialEq, Eq)]
 pub enum ChildEvent {
     /// Indicates the child has exited.
@@ -89,6 +96,7 @@ pub enum ChildEvent {
 /// This is a refinement of EventedReadWrite that also provides a channel through which we can be
 /// notified if the PTY child process does something we care about (other than writing to the TTY).
 /// In particular, this allows for race-free child exit notification on UNIX (cf. `SIGCHLD`).
+#[cfg(not(target_arch = "wasm32"))]
 pub trait EventedPty: EventedReadWrite {
     /// Tries to retrieve an event.
     ///
@@ -97,6 +105,7 @@ pub trait EventedPty: EventedReadWrite {
 }
 
 /// Setup environment variables.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn setup_env() {
     // Default to 'alacritty' terminfo if it is available, otherwise
     // default to 'xterm-256color'. May be overridden by user's config
@@ -109,6 +118,7 @@ pub fn setup_env() {
 }
 
 /// Check if a terminfo entry exists on the system.
+#[cfg(not(target_arch = "wasm32"))]
 fn terminfo_exists(terminfo: &str) -> bool {
     // Get first terminfo character for the parent directory.
     let first = terminfo.get(..1).unwrap_or_default();

--- a/alacritty_web/Cargo.toml
+++ b/alacritty_web/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "alacritty_web"
+version = "0.1.0"
+authors = ["Alacritty Contributors"]
+license = "Apache-2.0"
+description = "WASM/WebGPU terminal renderer based on Alacritty"
+edition.workspace = true
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+alacritty_terminal = { path = "../alacritty_terminal", default-features = false }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Document",
+    "Element",
+    "HtmlCanvasElement",
+    "OffscreenCanvas",
+    "CanvasRenderingContext2d",
+    "OffscreenCanvasRenderingContext2d",
+    "TextMetrics",
+    "WebSocket",
+    "MessageEvent",
+    "BinaryType",
+    "CloseEvent",
+    "ErrorEvent",
+    "KeyboardEvent",
+    "MouseEvent",
+    "WheelEvent",
+    "HtmlElement",
+    "ResizeObserver",
+    "ResizeObserverEntry",
+    "ResizeObserverSize",
+    "DomRectReadOnly",
+    "Navigator",
+    "Clipboard",
+    "console",
+    "Performance",
+    "GpuCanvasContext",
+    "ImageData",
+] }
+js-sys = "0.3"
+wgpu = { version = "24", features = ["webgl"] }
+bytemuck = { version = "1", features = ["derive"] }
+log = "0.4"
+console_log = "1"
+console_error_panic_hook = "0.1"
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/alacritty_web/src/lib.rs
+++ b/alacritty_web/src/lib.rs
@@ -1,0 +1,172 @@
+//! Alacritty Web - WASM terminal renderer.
+
+mod renderer;
+pub mod terminal;
+mod websocket;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use wasm_bindgen::prelude::*;
+use web_sys::HtmlCanvasElement;
+
+/// Initialize panic hook and logger for better WASM debugging.
+fn init_wasm() {
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Info).ok();
+}
+
+/// Shared state for the terminal + renderer.
+struct AppState {
+    renderer: renderer::canvas2d::Canvas2dRenderer,
+    terminal: terminal::WebTerminal,
+    dirty: bool,
+}
+
+/// The main Alacritty terminal component for the browser.
+#[wasm_bindgen]
+pub struct AlacrittyTerminal {
+    state: Rc<RefCell<AppState>>,
+    /// Incoming PTY data is queued here to avoid RefCell borrow conflicts.
+    incoming_data: Rc<RefCell<Vec<Vec<u8>>>>,
+    ws: Option<websocket::WsConnection>,
+    canvas: HtmlCanvasElement,
+}
+
+#[wasm_bindgen]
+impl AlacrittyTerminal {
+    /// Create a new terminal attached to the given canvas element.
+    #[wasm_bindgen(constructor)]
+    pub fn new(canvas: HtmlCanvasElement) -> Result<AlacrittyTerminal, JsError> {
+        init_wasm();
+        log::info!("Initializing AlacrittyTerminal");
+
+        let renderer = renderer::canvas2d::Canvas2dRenderer::new(&canvas)?;
+        let cell_w = renderer.cell_width();
+        let cell_h = renderer.cell_height();
+
+        let css_width = canvas.client_width().max(1) as f32;
+        let css_height = canvas.client_height().max(1) as f32;
+        let cols = (css_width / cell_w).floor().max(1.0) as u16;
+        let rows = (css_height / cell_h).floor().max(1.0) as u16;
+
+        log::info!("Initial grid: {cols}x{rows}");
+
+        let terminal = terminal::WebTerminal::new(cols, rows);
+
+        let state = Rc::new(RefCell::new(AppState {
+            renderer,
+            terminal,
+            dirty: true,
+        }));
+
+        let incoming_data: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let term = AlacrittyTerminal {
+            state,
+            incoming_data,
+            ws: None,
+            canvas,
+        };
+
+        term.start_render_loop();
+
+        Ok(term)
+    }
+
+    /// Connect to a WebSocket PTY server.
+    pub fn connect(&mut self, ws_url: &str) -> Result<(), JsError> {
+        // WebSocket data goes into the queue, not directly into the terminal.
+        let queue = self.incoming_data.clone();
+        let ws = websocket::WsConnection::new(ws_url, move |data| {
+            queue.borrow_mut().push(data.to_vec());
+        })?;
+        self.ws = Some(ws);
+        Ok(())
+    }
+
+    /// Disconnect from the PTY server.
+    pub fn disconnect(&mut self) {
+        self.ws = None;
+    }
+
+    /// Write data to the PTY (send input).
+    pub fn write(&self, data: &[u8]) {
+        if let Some(ws) = &self.ws {
+            ws.send_pty_data(data);
+        }
+    }
+
+    /// Send a resize message to the server.
+    pub fn resize(&mut self, cols: u16, rows: u16) {
+        self.state.borrow_mut().terminal.resize(cols, rows);
+        self.state.borrow_mut().dirty = true;
+        if let Some(ws) = &self.ws {
+            ws.send_resize(cols, rows, 0, 0);
+        }
+    }
+
+    /// Get cell width in pixels.
+    pub fn cell_width(&self) -> f32 {
+        self.state.borrow().renderer.cell_width()
+    }
+
+    /// Get cell height in pixels.
+    pub fn cell_height(&self) -> f32 {
+        self.state.borrow().renderer.cell_height()
+    }
+
+    /// Clean up resources.
+    pub fn dispose(self) {
+        drop(self);
+    }
+}
+
+impl AlacrittyTerminal {
+    /// Start the requestAnimationFrame render loop.
+    fn start_render_loop(&self) {
+        let state = self.state.clone();
+        let incoming = self.incoming_data.clone();
+        let callback = Rc::new(RefCell::new(None::<Closure<dyn FnMut()>>));
+        let callback_clone = callback.clone();
+
+        *callback.borrow_mut() = Some(Closure::wrap(Box::new(move || {
+            // Drain incoming data into the terminal.
+            let chunks: Vec<Vec<u8>> = incoming.borrow_mut().drain(..).collect();
+            if !chunks.is_empty() {
+                let mut app = state.borrow_mut();
+                for chunk in chunks {
+                    app.terminal.process_bytes(&chunk);
+                }
+                app.dirty = true;
+            }
+
+            // Render if dirty.
+            {
+                let mut app = state.borrow_mut();
+                if app.dirty {
+                    let term = app.terminal.term().clone();
+                    let term_guard = term.lock();
+                    app.renderer.render(&term_guard);
+                    drop(term_guard);
+                    app.dirty = false;
+                }
+            }
+
+            // Schedule next frame.
+            if let Some(win) = web_sys::window() {
+                if let Some(cb) = callback_clone.borrow().as_ref() {
+                    let _ = win.request_animation_frame(cb.as_ref().unchecked_ref());
+                }
+            }
+        }) as Box<dyn FnMut()>));
+
+        if let Some(win) = web_sys::window() {
+            if let Some(cb) = callback.borrow().as_ref() {
+                let _ = win.request_animation_frame(cb.as_ref().unchecked_ref());
+            }
+        }
+
+        std::mem::forget(callback);
+    }
+}

--- a/alacritty_web/src/renderer/canvas2d.rs
+++ b/alacritty_web/src/renderer/canvas2d.rs
@@ -1,0 +1,207 @@
+//! Canvas 2D fallback renderer for the terminal.
+//!
+//! Draws terminal content using the browser's Canvas 2D API.
+//! Works in every browser without WebGPU/WebGL requirements.
+
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::term::cell::Flags as CellFlags;
+use alacritty_terminal::term::Term;
+use alacritty_terminal::vte::ansi::NamedColor;
+
+use wasm_bindgen::prelude::*;
+use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
+
+use super::colors;
+use crate::terminal::WebEventProxy;
+
+/// Canvas 2D-based terminal renderer.
+pub struct Canvas2dRenderer {
+    canvas: HtmlCanvasElement,
+    ctx: CanvasRenderingContext2d,
+    font_family: String,
+    font_size_px: f32,
+    cell_width: f32,
+    cell_height: f32,
+    device_pixel_ratio: f64,
+}
+
+impl Canvas2dRenderer {
+    /// Create a new Canvas 2D renderer.
+    pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsError> {
+        let ctx = canvas
+            .get_context("2d")
+            .map_err(|e| JsError::new(&format!("Failed to get 2d context: {e:?}")))?
+            .ok_or_else(|| JsError::new("No 2d context"))?
+            .dyn_into::<CanvasRenderingContext2d>()
+            .map_err(|_| JsError::new("Not a CanvasRenderingContext2d"))?;
+
+        let font_family = "'Fira Code', 'Cascadia Code', 'Source Code Pro', monospace".to_string();
+        let font_size_px = 14.0;
+
+        // Measure cell dimensions.
+        let font_str = format!("{font_size_px}px {font_family}");
+        ctx.set_font(&font_str);
+        let metrics = ctx
+            .measure_text("M")
+            .map_err(|e| JsError::new(&format!("measureText failed: {e:?}")))?;
+
+        let cell_width = metrics.width() as f32;
+        let cell_height = (font_size_px * 1.4_f32).ceil();
+
+        // Handle device pixel ratio for sharp text.
+        let window = web_sys::window().ok_or_else(|| JsError::new("No window"))?;
+        let dpr = window.device_pixel_ratio();
+
+        // Set canvas backing store size.
+        let css_width = canvas.client_width() as u32;
+        let css_height = canvas.client_height() as u32;
+        canvas.set_width((css_width as f64 * dpr) as u32);
+        canvas.set_height((css_height as f64 * dpr) as u32);
+
+        // Scale context for HiDPI.
+        let _ = ctx.scale(dpr, dpr);
+
+        log::info!(
+            "Canvas2D renderer: cell={cell_width}x{cell_height}, dpr={dpr}, canvas={css_width}x{css_height}"
+        );
+
+        Ok(Self {
+            canvas: canvas.clone(),
+            ctx,
+            font_family,
+            font_size_px,
+            cell_width,
+            cell_height,
+            device_pixel_ratio: dpr,
+        })
+    }
+
+    /// Render the terminal state to the canvas.
+    pub fn render(&self, term: &Term<WebEventProxy>) {
+        let content = term.renderable_content();
+        let term_colors = content.colors;
+        let num_cols = term.columns();
+        let num_lines = term.screen_lines();
+
+        let bg_color = colors::default_named_color(NamedColor::Background);
+        let fg_default = colors::default_named_color(NamedColor::Foreground);
+
+        let cw = self.cell_width as f64;
+        let ch = self.cell_height as f64;
+        let total_width = num_cols as f64 * cw;
+        let total_height = num_lines as f64 * ch;
+
+        // Update canvas backing store if needed.
+        let dpr = self.device_pixel_ratio;
+        let needed_w = (total_width * dpr).ceil() as u32;
+        let needed_h = (total_height * dpr).ceil() as u32;
+        if self.canvas.width() != needed_w || self.canvas.height() != needed_h {
+            self.canvas.set_width(needed_w);
+            self.canvas.set_height(needed_h);
+            let _ = self.ctx.scale(dpr, dpr);
+        }
+
+        // Clear with background color.
+        self.ctx.set_fill_style_str(&format!(
+            "rgb({},{},{})",
+            bg_color.r, bg_color.g, bg_color.b
+        ));
+        self.ctx
+            .fill_rect(0.0, 0.0, total_width + 10.0, total_height + 10.0);
+
+        // Set font.
+        let font_str = format!("{}px {}", self.font_size_px, self.font_family);
+        self.ctx.set_font(&font_str);
+        self.ctx.set_text_baseline("top");
+
+        // Track which font variant we're using to minimize set_font calls.
+        let mut current_bold = false;
+        let mut current_italic = false;
+
+        for indexed in content.display_iter {
+            let point = indexed.point;
+            let cell = &indexed.cell;
+
+            // Skip wide char spacers.
+            if cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
+                continue;
+            }
+
+            let col = point.column.0 as f64;
+            let row = point.line.0 as f64;
+
+            let x = col * cw;
+            let y = row * ch;
+
+            // Resolve colors.
+            let cell_fg = colors::resolve_color(&cell.fg, term_colors);
+            let cell_bg = colors::resolve_color(&cell.bg, term_colors);
+
+            // Draw background if not default.
+            if cell_bg != bg_color {
+                let width_mult = if cell.flags.contains(CellFlags::WIDE_CHAR) {
+                    2.0
+                } else {
+                    1.0
+                };
+                self.ctx.set_fill_style_str(&format!(
+                    "rgb({},{},{})",
+                    cell_bg.r, cell_bg.g, cell_bg.b
+                ));
+                self.ctx.fill_rect(x, y, cw * width_mult, ch);
+            }
+
+            // Skip empty cells.
+            if cell.c == ' ' || cell.c == '\t' || cell.c == '\0' {
+                continue;
+            }
+
+            // Update font variant if needed.
+            let is_bold = cell.flags.contains(CellFlags::BOLD);
+            let is_italic = cell.flags.contains(CellFlags::ITALIC);
+            if is_bold != current_bold || is_italic != current_italic {
+                let weight = if is_bold { "bold " } else { "" };
+                let style = if is_italic { "italic " } else { "" };
+                let font_str =
+                    format!("{style}{weight}{}px {}", self.font_size_px, self.font_family);
+                self.ctx.set_font(&font_str);
+                current_bold = is_bold;
+                current_italic = is_italic;
+            }
+
+            // Draw character.
+            self.ctx.set_fill_style_str(&format!(
+                "rgb({},{},{})",
+                cell_fg.r, cell_fg.g, cell_fg.b
+            ));
+            let ch_str = cell.c.to_string();
+            let _ = self.ctx.fill_text(&ch_str, x, y + 2.0);
+        }
+
+        // Draw cursor.
+        let cursor = &content.cursor;
+        let cursor_color = colors::default_named_color(NamedColor::Cursor);
+        let cx = cursor.point.column.0 as f64 * cw;
+        let cy = cursor.point.line.0 as f64 * ch;
+        self.ctx.set_fill_style_str(&format!(
+            "rgba({},{},{},0.6)",
+            cursor_color.r, cursor_color.g, cursor_color.b
+        ));
+        self.ctx.fill_rect(cx, cy, cw, ch);
+    }
+
+    /// Cell width in pixels.
+    pub fn cell_width(&self) -> f32 {
+        self.cell_width
+    }
+
+    /// Cell height in pixels.
+    pub fn cell_height(&self) -> f32 {
+        self.cell_height
+    }
+
+    /// Resize the canvas.
+    pub fn resize(&self, _width: u32, _height: u32) {
+        // Canvas resize is handled in render() based on terminal dimensions.
+    }
+}

--- a/alacritty_web/src/renderer/colors.rs
+++ b/alacritty_web/src/renderer/colors.rs
@@ -1,0 +1,84 @@
+//! Default color theme and color resolution.
+//!
+//! Resolves terminal Color values to concrete RGB for rendering.
+
+use alacritty_terminal::term::color::Colors;
+use alacritty_terminal::vte::ansi::{Color, NamedColor, Rgb};
+
+/// Default Alacritty dark theme colors.
+pub fn default_named_color(color: NamedColor) -> Rgb {
+    match color {
+        NamedColor::Black => Rgb { r: 0x1d, g: 0x1f, b: 0x21 },
+        NamedColor::Red => Rgb { r: 0xcc, g: 0x66, b: 0x66 },
+        NamedColor::Green => Rgb { r: 0xb5, g: 0xbd, b: 0x68 },
+        NamedColor::Yellow => Rgb { r: 0xf0, g: 0xc6, b: 0x74 },
+        NamedColor::Blue => Rgb { r: 0x81, g: 0xa2, b: 0xbe },
+        NamedColor::Magenta => Rgb { r: 0xb2, g: 0x94, b: 0xbb },
+        NamedColor::Cyan => Rgb { r: 0x8a, g: 0xbe, b: 0xb7 },
+        NamedColor::White => Rgb { r: 0xc5, g: 0xc8, b: 0xc6 },
+        NamedColor::BrightBlack => Rgb { r: 0x96, g: 0x98, b: 0x96 },
+        NamedColor::BrightRed => Rgb { r: 0xcc, g: 0x66, b: 0x66 },
+        NamedColor::BrightGreen => Rgb { r: 0xb5, g: 0xbd, b: 0x68 },
+        NamedColor::BrightYellow => Rgb { r: 0xf0, g: 0xc6, b: 0x74 },
+        NamedColor::BrightBlue => Rgb { r: 0x81, g: 0xa2, b: 0xbe },
+        NamedColor::BrightMagenta => Rgb { r: 0xb2, g: 0x94, b: 0xbb },
+        NamedColor::BrightCyan => Rgb { r: 0x8a, g: 0xbe, b: 0xb7 },
+        NamedColor::BrightWhite => Rgb { r: 0xff, g: 0xff, b: 0xff },
+        NamedColor::Foreground => Rgb { r: 0xc5, g: 0xc8, b: 0xc6 },
+        NamedColor::Background => Rgb { r: 0x1d, g: 0x1f, b: 0x21 },
+        NamedColor::Cursor => Rgb { r: 0xc5, g: 0xc8, b: 0xc6 },
+        _ => Rgb { r: 0xc5, g: 0xc8, b: 0xc6 },
+    }
+}
+
+/// Resolve a 256-color indexed color to RGB.
+fn indexed_color(index: u8) -> Rgb {
+    if index < 16 {
+        // Standard ANSI colors.
+        let named = match index {
+            0 => NamedColor::Black,
+            1 => NamedColor::Red,
+            2 => NamedColor::Green,
+            3 => NamedColor::Yellow,
+            4 => NamedColor::Blue,
+            5 => NamedColor::Magenta,
+            6 => NamedColor::Cyan,
+            7 => NamedColor::White,
+            8 => NamedColor::BrightBlack,
+            9 => NamedColor::BrightRed,
+            10 => NamedColor::BrightGreen,
+            11 => NamedColor::BrightYellow,
+            12 => NamedColor::BrightBlue,
+            13 => NamedColor::BrightMagenta,
+            14 => NamedColor::BrightCyan,
+            15 => NamedColor::BrightWhite,
+            _ => unreachable!(),
+        };
+        default_named_color(named)
+    } else if index < 232 {
+        // 6x6x6 color cube.
+        let index = index as u16 - 16;
+        let r_idx = index / 36;
+        let g_idx = (index % 36) / 6;
+        let b_idx = index % 6;
+        let to_val = |i: u16| if i == 0 { 0u8 } else { (55 + 40 * i) as u8 };
+        Rgb { r: to_val(r_idx), g: to_val(g_idx), b: to_val(b_idx) }
+    } else {
+        // Grayscale ramp.
+        let val = 8 + 10 * (index - 232);
+        Rgb { r: val, g: val, b: val }
+    }
+}
+
+/// Resolve a terminal Color to RGB using the color palette.
+pub fn resolve_color(color: &Color, colors: &Colors) -> Rgb {
+    match color {
+        Color::Named(name) => {
+            colors[*name].unwrap_or_else(|| default_named_color(*name))
+        },
+        Color::Spec(rgb) => *rgb,
+        Color::Indexed(idx) => {
+            colors[*idx as usize].unwrap_or_else(|| indexed_color(*idx))
+        },
+    }
+}

--- a/alacritty_web/src/renderer/glyph_cache.rs
+++ b/alacritty_web/src/renderer/glyph_cache.rs
@@ -1,0 +1,276 @@
+//! Glyph rasterization and atlas management using Canvas 2D API.
+//!
+//! Glyphs are rasterized via an offscreen canvas using `fillText()`,
+//! then uploaded to a wgpu texture atlas.
+
+use std::collections::HashMap;
+
+use wasm_bindgen::prelude::*;
+
+/// Key identifying a specific glyph in the cache.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct GlyphKey {
+    pub character: char,
+    pub bold: bool,
+    pub italic: bool,
+}
+
+/// Cached glyph location in the atlas.
+#[derive(Clone, Copy, Debug)]
+pub struct GlyphEntry {
+    /// UV coordinates in the atlas (normalized 0-1).
+    pub uv_x: f32,
+    pub uv_y: f32,
+    pub uv_w: f32,
+    pub uv_h: f32,
+    /// Glyph metrics in pixels.
+    pub width: u32,
+    pub height: u32,
+    pub bearing_x: f32,
+    pub bearing_y: f32,
+}
+
+/// Atlas packer using simple row-based allocation.
+struct AtlasPacker {
+    width: u32,
+    height: u32,
+    cursor_x: u32,
+    cursor_y: u32,
+    row_height: u32,
+}
+
+impl AtlasPacker {
+    fn new(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            cursor_x: 0,
+            cursor_y: 0,
+            row_height: 0,
+        }
+    }
+
+    /// Allocate space for a glyph. Returns (x, y) position in the atlas.
+    fn allocate(&mut self, glyph_w: u32, glyph_h: u32) -> Option<(u32, u32)> {
+        if self.cursor_x + glyph_w > self.width {
+            // Move to next row.
+            self.cursor_x = 0;
+            self.cursor_y += self.row_height + 1;
+            self.row_height = 0;
+        }
+
+        if self.cursor_y + glyph_h > self.height {
+            return None; // Atlas full.
+        }
+
+        let pos = (self.cursor_x, self.cursor_y);
+        self.cursor_x += glyph_w + 1;
+        self.row_height = self.row_height.max(glyph_h);
+
+        Some(pos)
+    }
+}
+
+/// Glyph cache using Canvas 2D for rasterization and wgpu texture atlas.
+pub struct GlyphCache {
+    cache: HashMap<GlyphKey, GlyphEntry>,
+    rasterize_canvas: web_sys::OffscreenCanvas,
+    rasterize_ctx: web_sys::OffscreenCanvasRenderingContext2d,
+    atlas_texture: wgpu::Texture,
+    atlas_view: wgpu::TextureView,
+    atlas_sampler: wgpu::Sampler,
+    packer: AtlasPacker,
+    font_family: String,
+    font_size_px: f32,
+    cell_width: f32,
+    cell_height: f32,
+}
+
+const ATLAS_SIZE: u32 = 2048;
+
+impl GlyphCache {
+    /// Create a new glyph cache.
+    pub fn new(
+        device: &wgpu::Device,
+        font_family: &str,
+        font_size_px: f32,
+    ) -> Result<Self, JsError> {
+        // Create offscreen canvas for rasterization.
+        let rasterize_canvas = web_sys::OffscreenCanvas::new(256, 256)
+            .map_err(|e| JsError::new(&format!("Failed to create offscreen canvas: {e:?}")))?;
+
+        let rasterize_ctx = rasterize_canvas
+            .get_context("2d")
+            .map_err(|e| JsError::new(&format!("Failed to get 2d context: {e:?}")))?
+            .ok_or_else(|| JsError::new("No 2d context"))?
+            .dyn_into::<web_sys::OffscreenCanvasRenderingContext2d>()
+            .map_err(|_| JsError::new("Context is not OffscreenCanvasRenderingContext2d"))?;
+
+        // Measure cell dimensions using the font.
+        let font_str = format!("{font_size_px}px {font_family}");
+        rasterize_ctx.set_font(&font_str);
+        let metrics = rasterize_ctx.measure_text("M")
+            .map_err(|e| JsError::new(&format!("measureText failed: {e:?}")))?;
+
+        let cell_width = metrics.width() as f32;
+        // Approximate cell height from font size (line height ~ 1.2x).
+        let cell_height = (font_size_px * 1.2).ceil();
+
+        // Create the atlas texture.
+        let atlas_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("glyph_atlas"),
+            size: wgpu::Extent3d {
+                width: ATLAS_SIZE,
+                height: ATLAS_SIZE,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        let atlas_view = atlas_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let atlas_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("glyph_atlas_sampler"),
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        Ok(Self {
+            cache: HashMap::new(),
+            rasterize_canvas,
+            rasterize_ctx,
+            atlas_texture,
+            atlas_view,
+            atlas_sampler,
+            packer: AtlasPacker::new(ATLAS_SIZE, ATLAS_SIZE),
+            font_family: font_family.to_string(),
+            font_size_px,
+            cell_width,
+            cell_height,
+        })
+    }
+
+    /// Get or rasterize a glyph.
+    pub fn get_or_insert(
+        &mut self,
+        key: &GlyphKey,
+        queue: &wgpu::Queue,
+    ) -> GlyphEntry {
+        if let Some(entry) = self.cache.get(key) {
+            return *entry;
+        }
+
+        let entry = self.rasterize_glyph(key, queue);
+        self.cache.insert(key.clone(), entry);
+        entry
+    }
+
+    /// Rasterize a glyph using Canvas 2D and upload to the atlas.
+    fn rasterize_glyph(
+        &mut self,
+        key: &GlyphKey,
+        queue: &wgpu::Queue,
+    ) -> GlyphEntry {
+        let ch = key.character.to_string();
+
+        // Build font string.
+        let weight = if key.bold { "bold " } else { "" };
+        let style = if key.italic { "italic " } else { "" };
+        let font_str = format!("{style}{weight}{}px {}", self.font_size_px, self.font_family);
+
+        // Set up the rasterization canvas.
+        let glyph_w = (self.cell_width.ceil() as u32).max(1);
+        let glyph_h = (self.cell_height.ceil() as u32).max(1);
+
+        self.rasterize_canvas.set_width(glyph_w);
+        self.rasterize_canvas.set_height(glyph_h);
+
+        let ctx = &self.rasterize_ctx;
+        ctx.set_font(&font_str);
+        ctx.set_fill_style_str("white");
+        ctx.set_text_baseline("top");
+
+        // Clear and draw.
+        ctx.clear_rect(0.0, 0.0, glyph_w as f64, glyph_h as f64);
+        let _ = ctx.fill_text(&ch, 0.0, 0.0);
+
+        // Read pixel data.
+        let image_data = ctx
+            .get_image_data(0.0, 0.0, glyph_w as f64, glyph_h as f64)
+            .ok();
+
+        // Allocate space in the atlas.
+        let (atlas_x, atlas_y) = self.packer.allocate(glyph_w, glyph_h).unwrap_or((0, 0));
+
+        // Extract alpha channel and upload to atlas.
+        if let Some(image_data) = image_data {
+            let rgba = image_data.data();
+            let mut alpha_data = vec![0u8; (glyph_w * glyph_h) as usize];
+            for i in 0..alpha_data.len() {
+                // Use red channel (white text on transparent bg).
+                alpha_data[i] = rgba[i * 4];
+            }
+
+            queue.write_texture(
+                wgpu::TexelCopyTextureInfo {
+                    texture: &self.atlas_texture,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d {
+                        x: atlas_x,
+                        y: atlas_y,
+                        z: 0,
+                    },
+                    aspect: wgpu::TextureAspect::All,
+                },
+                &alpha_data,
+                wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(glyph_w),
+                    rows_per_image: Some(glyph_h),
+                },
+                wgpu::Extent3d {
+                    width: glyph_w,
+                    height: glyph_h,
+                    depth_or_array_layers: 1,
+                },
+            );
+        }
+
+        let atlas_size = ATLAS_SIZE as f32;
+        GlyphEntry {
+            uv_x: atlas_x as f32 / atlas_size,
+            uv_y: atlas_y as f32 / atlas_size,
+            uv_w: glyph_w as f32 / atlas_size,
+            uv_h: glyph_h as f32 / atlas_size,
+            width: glyph_w,
+            height: glyph_h,
+            bearing_x: 0.0,
+            bearing_y: 0.0,
+        }
+    }
+
+    /// Get the atlas texture view.
+    pub fn atlas_view(&self) -> &wgpu::TextureView {
+        &self.atlas_view
+    }
+
+    /// Get the atlas sampler.
+    pub fn atlas_sampler(&self) -> &wgpu::Sampler {
+        &self.atlas_sampler
+    }
+
+    /// Cell dimensions in pixels.
+    pub fn cell_width(&self) -> f32 {
+        self.cell_width
+    }
+
+    pub fn cell_height(&self) -> f32 {
+        self.cell_height
+    }
+}

--- a/alacritty_web/src/renderer/mod.rs
+++ b/alacritty_web/src/renderer/mod.rs
@@ -1,0 +1,297 @@
+//! Terminal renderers (wgpu and Canvas 2D fallback).
+
+pub mod canvas2d;
+pub mod colors;
+mod glyph_cache;
+mod rects;
+mod text;
+
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::term::cell::Flags as CellFlags;
+use alacritty_terminal::term::Term;
+use alacritty_terminal::vte::ansi::NamedColor;
+
+use wasm_bindgen::prelude::*;
+use web_sys::HtmlCanvasElement;
+
+use crate::terminal::WebEventProxy;
+
+/// The main wgpu renderer.
+pub struct WgpuRenderer {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    surface: wgpu::Surface<'static>,
+    surface_config: wgpu::SurfaceConfiguration,
+    text_renderer: text::TextRenderer,
+    rect_renderer: rects::RectRenderer,
+    glyph_cache: Option<glyph_cache::GlyphCache>,
+    cell_width: f32,
+    cell_height: f32,
+}
+
+impl WgpuRenderer {
+    /// Initialize wgpu from a canvas element.
+    pub async fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsError> {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
+            ..Default::default()
+        });
+
+        let surface_target = wgpu::SurfaceTarget::Canvas(canvas.clone());
+        let surface = instance
+            .create_surface(surface_target)
+            .map_err(|e| JsError::new(&format!("Failed to create surface: {e}")))?;
+
+        let adapter = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
+            })
+            .await
+            .ok_or_else(|| JsError::new("Failed to find a suitable GPU adapter"))?;
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("alacritty_device"),
+                    required_features: wgpu::Features::empty(),
+                    required_limits: wgpu::Limits::downlevel_webgl2_defaults(),
+                    memory_hints: wgpu::MemoryHints::Performance,
+                },
+                None,
+            )
+            .await
+            .map_err(|e| JsError::new(&format!("Failed to create device: {e}")))?;
+
+        let width = canvas.client_width().max(1) as u32;
+        let height = canvas.client_height().max(1) as u32;
+
+        let surface_caps = surface.get_capabilities(&adapter);
+        let surface_format = surface_caps
+            .formats
+            .iter()
+            .find(|f| f.is_srgb())
+            .copied()
+            .unwrap_or(surface_caps.formats[0]);
+
+        let surface_config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: surface_format,
+            width,
+            height,
+            present_mode: wgpu::PresentMode::AutoVsync,
+            alpha_mode: surface_caps.alpha_modes[0],
+            view_formats: vec![],
+            desired_maximum_frame_latency: 2,
+        };
+        surface.configure(&device, &surface_config);
+
+        let text_renderer = text::TextRenderer::new(&device, surface_format);
+        let rect_renderer = rects::RectRenderer::new(&device, surface_format);
+
+        // Initialize glyph cache.
+        let glyph_cache =
+            glyph_cache::GlyphCache::new(&device, "'Fira Code', 'Cascadia Code', monospace", 14.0)
+                .ok();
+
+        let (cell_width, cell_height) = glyph_cache
+            .as_ref()
+            .map(|gc| (gc.cell_width(), gc.cell_height()))
+            .unwrap_or((8.0, 16.0));
+
+        log::info!(
+            "wgpu renderer initialized: {width}x{height}, cell: {cell_width}x{cell_height}"
+        );
+
+        Ok(Self {
+            device,
+            queue,
+            surface,
+            surface_config,
+            text_renderer,
+            rect_renderer,
+            glyph_cache,
+            cell_width,
+            cell_height,
+        })
+    }
+
+    /// Resize the rendering surface.
+    pub fn resize(&mut self, width: u32, height: u32) {
+        if width > 0 && height > 0 {
+            self.surface_config.width = width;
+            self.surface_config.height = height;
+            self.surface.configure(&self.device, &self.surface_config);
+        }
+    }
+
+    /// Update render state from terminal grid.
+    pub fn update_from_terminal(&mut self, term: &Term<WebEventProxy>) {
+        let content = term.renderable_content();
+        let term_colors = content.colors;
+
+        let mut text_instances = Vec::new();
+        let mut rect_instances = Vec::new();
+
+        let bg_color = colors::default_named_color(NamedColor::Background);
+
+        for indexed in content.display_iter {
+            let point = indexed.point;
+            let cell = &indexed.cell;
+
+            // Skip wide char spacers.
+            if cell.flags.contains(CellFlags::WIDE_CHAR_SPACER) {
+                continue;
+            }
+
+            let col = point.column.0 as f32;
+            let row = (point.line.0 as i32 + term.screen_lines() as i32) as f32;
+
+            // Resolve colors.
+            let fg_rgb = colors::resolve_color(&cell.fg, term_colors);
+            let bg_rgb = colors::resolve_color(&cell.bg, term_colors);
+
+            // Add background rect if not default.
+            if bg_rgb != bg_color {
+                let width_mult = if cell.flags.contains(CellFlags::WIDE_CHAR) {
+                    2.0
+                } else {
+                    1.0
+                };
+                rect_instances.push(rects::RectInstance {
+                    pos_x: col * self.cell_width,
+                    pos_y: row * self.cell_height,
+                    size_w: self.cell_width * width_mult,
+                    size_h: self.cell_height,
+                    color_r: bg_rgb.r as f32 / 255.0,
+                    color_g: bg_rgb.g as f32 / 255.0,
+                    color_b: bg_rgb.b as f32 / 255.0,
+                    color_a: 1.0,
+                });
+            }
+
+            // Skip empty/space cells for text rendering.
+            if cell.c == ' ' || cell.c == '\t' || cell.c == '\0' {
+                continue;
+            }
+
+            // Get glyph from cache.
+            if let Some(cache) = &mut self.glyph_cache {
+                let glyph_key = glyph_cache::GlyphKey {
+                    character: cell.c,
+                    bold: cell.flags.contains(CellFlags::BOLD),
+                    italic: cell.flags.contains(CellFlags::ITALIC),
+                };
+
+                let glyph = cache.get_or_insert(&glyph_key, &self.queue);
+
+                text_instances.push(text::CellInstance {
+                    grid_col: col,
+                    grid_row: row,
+                    uv_x: glyph.uv_x,
+                    uv_y: glyph.uv_y,
+                    uv_w: glyph.uv_w,
+                    uv_h: glyph.uv_h,
+                    fg_r: fg_rgb.r as f32 / 255.0,
+                    fg_g: fg_rgb.g as f32 / 255.0,
+                    fg_b: fg_rgb.b as f32 / 255.0,
+                    fg_a: 1.0,
+                    bg_r: bg_rgb.r as f32 / 255.0,
+                    bg_g: bg_rgb.g as f32 / 255.0,
+                    bg_b: bg_rgb.b as f32 / 255.0,
+                    bg_a: if bg_rgb != bg_color { 1.0 } else { 0.0 },
+                });
+            }
+        }
+
+        // Add cursor rect.
+        let cursor = &content.cursor;
+        let cursor_color = colors::default_named_color(NamedColor::Cursor);
+        rect_instances.push(rects::RectInstance {
+            pos_x: cursor.point.column.0 as f32 * self.cell_width,
+            pos_y: (cursor.point.line.0 as i32 + term.screen_lines() as i32) as f32
+                * self.cell_height,
+            size_w: self.cell_width,
+            size_h: self.cell_height,
+            color_r: cursor_color.r as f32 / 255.0,
+            color_g: cursor_color.g as f32 / 255.0,
+            color_b: cursor_color.b as f32 / 255.0,
+            color_a: 0.5,
+        });
+
+        // Update GPU buffers.
+        self.rect_renderer
+            .update_instances(&self.device, &rect_instances);
+        self.text_renderer.update_instances(
+            &self.device,
+            &self.queue,
+            &text_instances,
+            self.cell_width,
+            self.cell_height,
+            self.surface_config.width as f32,
+            self.surface_config.height as f32,
+            self.glyph_cache.as_ref(),
+        );
+    }
+
+    /// Render a frame.
+    pub fn render(&mut self) -> Result<(), JsError> {
+        let output = self
+            .surface
+            .get_current_texture()
+            .map_err(|e| JsError::new(&format!("Surface error: {e}")))?;
+
+        let view = output
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        let mut encoder =
+            self.device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("render_encoder"),
+                });
+
+        {
+            let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("main_render_pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color {
+                            r: 0.114,
+                            g: 0.122,
+                            b: 0.129,
+                            a: 1.0,
+                        }),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+
+            // Draw rectangles (backgrounds, cursor, selection).
+            self.rect_renderer.draw(&mut render_pass);
+
+            // Draw text.
+            self.text_renderer.draw(&mut render_pass);
+        }
+
+        self.queue.submit(std::iter::once(encoder.finish()));
+        output.present();
+
+        Ok(())
+    }
+
+    /// Cell dimensions.
+    pub fn cell_width(&self) -> f32 {
+        self.cell_width
+    }
+
+    pub fn cell_height(&self) -> f32 {
+        self.cell_height
+    }
+}

--- a/alacritty_web/src/renderer/rects.rs
+++ b/alacritty_web/src/renderer/rects.rs
@@ -1,0 +1,226 @@
+//! Rectangle rendering for underlines, cursor, selection highlights.
+//!
+//! Uses a simple solid-color quad pipeline.
+
+use wgpu::util::DeviceExt;
+
+/// Per-instance data for a rectangle.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct RectInstance {
+    /// Position in pixels (x, y).
+    pub pos_x: f32,
+    pub pos_y: f32,
+    /// Size in pixels (width, height).
+    pub size_w: f32,
+    pub size_h: f32,
+    /// Color (RGBA).
+    pub color_r: f32,
+    pub color_g: f32,
+    pub color_b: f32,
+    pub color_a: f32,
+}
+
+/// Uniforms for the rect shader.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct RectUniforms {
+    /// Orthographic projection matrix (column-major).
+    pub projection: [f32; 16],
+}
+
+const RECT_SHADER: &str = r#"
+struct RectUniforms {
+    projection: mat4x4<f32>,
+}
+
+struct RectInstance {
+    @location(0) pos: vec2<f32>,
+    @location(1) size: vec2<f32>,
+    @location(2) color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> uniforms: RectUniforms;
+
+var<private> QUAD_VERTICES: array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, 1.0),
+);
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vertex_index: u32,
+    instance: RectInstance,
+) -> VertexOutput {
+    var out: VertexOutput;
+
+    let quad_pos = QUAD_VERTICES[vertex_index];
+    let pos = instance.pos + quad_pos * instance.size;
+
+    out.position = uniforms.projection * vec4<f32>(pos, 0.0, 1.0);
+    out.color = instance.color;
+
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    return in.color;
+}
+"#;
+
+/// Renderer for solid-color rectangles.
+pub struct RectRenderer {
+    pipeline: wgpu::RenderPipeline,
+    uniform_buffer: wgpu::Buffer,
+    bind_group: wgpu::BindGroup,
+    instance_buffer: Option<wgpu::Buffer>,
+    instance_count: u32,
+}
+
+impl RectRenderer {
+    pub fn new(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("rect_shader"),
+            source: wgpu::ShaderSource::Wgsl(RECT_SHADER.into()),
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("rect_bind_group_layout"),
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("rect_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let instance_layout = wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<RectInstance>() as u64,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &[
+                // pos (x, y)
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 0,
+                    format: wgpu::VertexFormat::Float32x2,
+                },
+                // size (w, h)
+                wgpu::VertexAttribute {
+                    offset: 8,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x2,
+                },
+                // color (rgba)
+                wgpu::VertexAttribute {
+                    offset: 16,
+                    shader_location: 2,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+            ],
+        };
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("rect_pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[instance_layout],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("rect_uniform_buffer"),
+            contents: bytemuck::bytes_of(&RectUniforms {
+                projection: super::text::orthographic_projection(800.0, 600.0),
+            }),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("rect_bind_group"),
+            layout: &bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        Self {
+            pipeline,
+            uniform_buffer,
+            bind_group,
+            instance_buffer: None,
+            instance_count: 0,
+        }
+    }
+
+    /// Update the rectangle instances to draw.
+    pub fn update_instances(&mut self, device: &wgpu::Device, instances: &[RectInstance]) {
+        self.instance_count = instances.len() as u32;
+        if instances.is_empty() {
+            self.instance_buffer = None;
+            return;
+        }
+
+        self.instance_buffer = Some(device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("rect_instance_buffer"),
+            contents: bytemuck::cast_slice(instances),
+            usage: wgpu::BufferUsages::VERTEX,
+        }));
+    }
+
+    /// Draw rectangles within a render pass.
+    pub fn draw<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
+        if self.instance_count == 0 {
+            return;
+        }
+
+        if let Some(buf) = &self.instance_buffer {
+            render_pass.set_pipeline(&self.pipeline);
+            render_pass.set_bind_group(0, &self.bind_group, &[]);
+            render_pass.set_vertex_buffer(0, buf.slice(..));
+            render_pass.draw(0..6, 0..self.instance_count);
+        }
+    }
+}

--- a/alacritty_web/src/renderer/text.rs
+++ b/alacritty_web/src/renderer/text.rs
@@ -1,0 +1,406 @@
+//! Text rendering pipeline using wgpu instanced rendering.
+//!
+//! Each terminal cell is rendered as a textured quad via instancing.
+//! Two passes: background quads first, then text quads with alpha blending.
+
+use wgpu::util::DeviceExt;
+
+use super::glyph_cache::GlyphCache;
+
+/// Per-instance data for a single terminal cell.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct CellInstance {
+    /// Grid position (col, row) in cell units.
+    pub grid_col: f32,
+    pub grid_row: f32,
+    /// UV coordinates in the glyph atlas (x, y, w, h) normalized.
+    pub uv_x: f32,
+    pub uv_y: f32,
+    pub uv_w: f32,
+    pub uv_h: f32,
+    /// Foreground color (RGBA).
+    pub fg_r: f32,
+    pub fg_g: f32,
+    pub fg_b: f32,
+    pub fg_a: f32,
+    /// Background color (RGBA).
+    pub bg_r: f32,
+    pub bg_g: f32,
+    pub bg_b: f32,
+    pub bg_a: f32,
+}
+
+/// Uniforms for the text shader.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct TextUniforms {
+    /// Orthographic projection matrix (column-major).
+    pub projection: [f32; 16],
+    /// Cell dimensions in pixels.
+    pub cell_width: f32,
+    pub cell_height: f32,
+    /// Pass type: 0 = background, 1 = text.
+    pub pass_type: u32,
+    pub _padding: u32,
+}
+
+const TEXT_SHADER: &str = r#"
+struct TextUniforms {
+    projection: mat4x4<f32>,
+    cell_width: f32,
+    cell_height: f32,
+    pass_type: u32,
+    _padding: u32,
+}
+
+struct CellInstance {
+    @location(0) grid_pos: vec2<f32>,
+    @location(1) uv_rect: vec4<f32>,
+    @location(2) fg_color: vec4<f32>,
+    @location(3) bg_color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+    @location(1) fg_color: vec4<f32>,
+    @location(2) bg_color: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> uniforms: TextUniforms;
+
+@group(0) @binding(1)
+var atlas_texture: texture_2d<f32>;
+
+@group(0) @binding(2)
+var atlas_sampler: sampler;
+
+// Quad vertices: two triangles forming a unit quad.
+var<private> QUAD_VERTICES: array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, 1.0),
+);
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vertex_index: u32,
+    instance: CellInstance,
+) -> VertexOutput {
+    var out: VertexOutput;
+
+    let quad_pos = QUAD_VERTICES[vertex_index];
+
+    // Cell position in pixels.
+    let pixel_pos = vec2<f32>(
+        instance.grid_pos.x * uniforms.cell_width,
+        instance.grid_pos.y * uniforms.cell_height,
+    );
+
+    // Scale quad to cell size and offset.
+    let pos = pixel_pos + quad_pos * vec2<f32>(uniforms.cell_width, uniforms.cell_height);
+
+    out.position = uniforms.projection * vec4<f32>(pos, 0.0, 1.0);
+
+    // UV mapping into the atlas.
+    out.uv = instance.uv_rect.xy + quad_pos * instance.uv_rect.zw;
+
+    out.fg_color = instance.fg_color;
+    out.bg_color = instance.bg_color;
+
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    if uniforms.pass_type == 0u {
+        // Background pass: solid color.
+        if in.bg_color.a < 0.001 {
+            discard;
+        }
+        return in.bg_color;
+    } else {
+        // Text pass: sample glyph alpha from atlas, apply foreground color.
+        let glyph_alpha = textureSample(atlas_texture, atlas_sampler, in.uv).r;
+        if glyph_alpha < 0.01 {
+            discard;
+        }
+        return vec4<f32>(in.fg_color.rgb, in.fg_color.a * glyph_alpha);
+    }
+}
+"#;
+
+/// Text renderer using instanced quad rendering.
+pub struct TextRenderer {
+    pipeline_bg: wgpu::RenderPipeline,
+    pipeline_text: wgpu::RenderPipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    bind_group: Option<wgpu::BindGroup>,
+    uniform_buffer: wgpu::Buffer,
+    instance_buffer: Option<wgpu::Buffer>,
+    instance_count: u32,
+}
+
+impl TextRenderer {
+    pub fn new(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("text_shader"),
+            source: wgpu::ShaderSource::Wgsl(TEXT_SHADER.into()),
+        });
+
+        let bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("text_bind_group_layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("text_pipeline_layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let instance_layout = wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<CellInstance>() as u64,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: &[
+                wgpu::VertexAttribute {
+                    offset: 0,
+                    shader_location: 0,
+                    format: wgpu::VertexFormat::Float32x2,
+                },
+                wgpu::VertexAttribute {
+                    offset: 8,
+                    shader_location: 1,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+                wgpu::VertexAttribute {
+                    offset: 24,
+                    shader_location: 2,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+                wgpu::VertexAttribute {
+                    offset: 40,
+                    shader_location: 3,
+                    format: wgpu::VertexFormat::Float32x4,
+                },
+            ],
+        };
+
+        let pipeline_bg = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("text_pipeline_bg"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[instance_layout.clone()],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let pipeline_text = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("text_pipeline_text"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[instance_layout],
+                compilation_options: Default::default(),
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: surface_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+                compilation_options: Default::default(),
+            }),
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("text_uniform_buffer"),
+            contents: bytemuck::bytes_of(&TextUniforms {
+                projection: orthographic_projection(800.0, 600.0),
+                cell_width: 8.0,
+                cell_height: 16.0,
+                pass_type: 0,
+                _padding: 0,
+            }),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        Self {
+            pipeline_bg,
+            pipeline_text,
+            bind_group_layout,
+            bind_group: None,
+            uniform_buffer,
+            instance_buffer: None,
+            instance_count: 0,
+        }
+    }
+
+    /// Update instance buffer and bind group from cell data.
+    pub fn update_instances(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        instances: &[CellInstance],
+        cell_width: f32,
+        cell_height: f32,
+        viewport_width: f32,
+        viewport_height: f32,
+        glyph_cache: Option<&GlyphCache>,
+    ) {
+        self.instance_count = instances.len() as u32;
+
+        // Update uniforms.
+        let uniforms = TextUniforms {
+            projection: orthographic_projection(viewport_width, viewport_height),
+            cell_width,
+            cell_height,
+            pass_type: 0, // Updated per-pass in draw.
+            _padding: 0,
+        };
+        queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
+
+        if instances.is_empty() {
+            self.instance_buffer = None;
+            self.bind_group = None;
+            return;
+        }
+
+        self.instance_buffer = Some(device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("text_instance_buffer"),
+            contents: bytemuck::cast_slice(instances),
+            usage: wgpu::BufferUsages::VERTEX,
+        }));
+
+        // Create bind group with atlas texture.
+        if let Some(cache) = glyph_cache {
+            self.bind_group = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("text_bind_group"),
+                layout: &self.bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: self.uniform_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::TextureView(cache.atlas_view()),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: wgpu::BindingResource::Sampler(cache.atlas_sampler()),
+                    },
+                ],
+            }));
+        }
+    }
+
+    /// Draw text (called within a render pass).
+    pub fn draw<'a>(&'a self, render_pass: &mut wgpu::RenderPass<'a>) {
+        if self.instance_count == 0 {
+            return;
+        }
+
+        let (Some(buf), Some(bind_group)) = (&self.instance_buffer, &self.bind_group) else {
+            return;
+        };
+
+        // Background pass.
+        render_pass.set_pipeline(&self.pipeline_bg);
+        render_pass.set_bind_group(0, bind_group, &[]);
+        render_pass.set_vertex_buffer(0, buf.slice(..));
+        render_pass.draw(0..6, 0..self.instance_count);
+
+        // Text pass.
+        render_pass.set_pipeline(&self.pipeline_text);
+        render_pass.set_bind_group(0, bind_group, &[]);
+        render_pass.set_vertex_buffer(0, buf.slice(..));
+        render_pass.draw(0..6, 0..self.instance_count);
+    }
+}
+
+/// Create an orthographic projection matrix (column-major).
+pub fn orthographic_projection(width: f32, height: f32) -> [f32; 16] {
+    [
+        2.0 / width,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        -2.0 / height,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        -1.0,
+        1.0,
+        0.0,
+        1.0,
+    ]
+}

--- a/alacritty_web/src/terminal.rs
+++ b/alacritty_web/src/terminal.rs
@@ -1,0 +1,99 @@
+//! Web terminal state wrapper around alacritty_terminal::Term.
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::sync::FairMutex;
+use alacritty_terminal::term::Config as TermConfig;
+use alacritty_terminal::Term;
+use alacritty_terminal::vte::ansi;
+
+use std::rc::Rc;
+
+/// Simple dimensions type for terminal sizing.
+struct TermSize {
+    lines: usize,
+    cols: usize,
+}
+
+impl Dimensions for TermSize {
+    fn total_lines(&self) -> usize {
+        self.lines
+    }
+
+    fn screen_lines(&self) -> usize {
+        self.lines
+    }
+
+    fn columns(&self) -> usize {
+        self.cols
+    }
+}
+
+/// Event listener that collects events for the web frontend.
+#[derive(Clone)]
+pub struct WebEventProxy {
+    // Events are processed inline on WASM (single-threaded).
+}
+
+impl WebEventProxy {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl EventListener for WebEventProxy {
+    fn send_event(&self, event: Event) {
+        match event {
+            Event::Wakeup => {
+                // Terminal content changed, schedule a redraw.
+            },
+            Event::Title(title) => {
+                log::info!("Terminal title: {title}");
+            },
+            Event::Bell => {
+                log::debug!("Terminal bell");
+            },
+            _ => {},
+        }
+    }
+}
+
+/// Wrapper around the terminal state for web usage.
+pub struct WebTerminal {
+    term: Rc<FairMutex<Term<WebEventProxy>>>,
+    parser: ansi::Processor,
+}
+
+impl WebTerminal {
+    /// Create a new terminal with the given dimensions.
+    pub fn new(cols: u16, lines: u16) -> Self {
+        let event_proxy = WebEventProxy::new();
+        let size = TermSize { lines: lines as usize, cols: cols as usize };
+        let config = TermConfig::default();
+        let term = Term::new(config, &size, event_proxy);
+        let term = Rc::new(FairMutex::new(term));
+
+        Self {
+            term,
+            parser: ansi::Processor::new(),
+        }
+    }
+
+    /// Feed bytes from the PTY into the terminal parser.
+    pub fn process_bytes(&mut self, bytes: &[u8]) {
+        let mut term = self.term.lock();
+        self.parser.advance(&mut *term, bytes);
+    }
+
+    /// Resize the terminal grid.
+    pub fn resize(&mut self, cols: u16, lines: u16) {
+        let size = TermSize { lines: lines as usize, cols: cols as usize };
+        let mut term = self.term.lock();
+        term.resize(size);
+    }
+
+    /// Get a reference to the terminal state for rendering.
+    pub fn term(&self) -> &Rc<FairMutex<Term<WebEventProxy>>> {
+        &self.term
+    }
+}

--- a/alacritty_web/src/websocket.rs
+++ b/alacritty_web/src/websocket.rs
@@ -1,0 +1,104 @@
+//! WebSocket client for PTY communication.
+//!
+//! Binary protocol:
+//! - 0x00 + bytes = PTY data (bidirectional)
+//! - 0x01 + 4x u16 LE (cols, rows, cell_w, cell_h) = resize (client->server)
+//! - 0x02 + optional exit code = child exited (server->client)
+
+use wasm_bindgen::prelude::*;
+use web_sys::{BinaryType, MessageEvent, WebSocket};
+
+const MSG_PTY_DATA: u8 = 0x00;
+const MSG_RESIZE: u8 = 0x01;
+const MSG_CHILD_EXIT: u8 = 0x02;
+
+/// WebSocket connection to the PTY server.
+pub struct WsConnection {
+    ws: WebSocket,
+    _on_message: Closure<dyn FnMut(MessageEvent)>,
+    _on_error: Closure<dyn FnMut(web_sys::ErrorEvent)>,
+    _on_close: Closure<dyn FnMut(web_sys::CloseEvent)>,
+}
+
+impl WsConnection {
+    /// Create a new WebSocket connection with a callback for incoming PTY data.
+    pub fn new<F>(url: &str, on_pty_data: F) -> Result<Self, JsError>
+    where
+        F: Fn(&[u8]) + 'static,
+    {
+        let ws = WebSocket::new(url).map_err(|e| JsError::new(&format!("{e:?}")))?;
+        ws.set_binary_type(BinaryType::Arraybuffer);
+
+        let on_message = Closure::wrap(Box::new(move |event: MessageEvent| {
+            if let Ok(buf) = event.data().dyn_into::<js_sys::ArrayBuffer>() {
+                let arr = js_sys::Uint8Array::new(&buf);
+                let data = arr.to_vec();
+                if data.is_empty() {
+                    return;
+                }
+
+                match data[0] {
+                    MSG_PTY_DATA => {
+                        if data.len() > 1 {
+                            on_pty_data(&data[1..]);
+                        }
+                    },
+                    MSG_CHILD_EXIT => {
+                        log::info!("Child process exited");
+                    },
+                    other => {
+                        log::warn!("Unknown message type: {other}");
+                    },
+                }
+            }
+        }) as Box<dyn FnMut(MessageEvent)>);
+
+        let on_error = Closure::wrap(Box::new(move |e: web_sys::ErrorEvent| {
+            log::error!("WebSocket error: {:?}", e.message());
+        }) as Box<dyn FnMut(web_sys::ErrorEvent)>);
+
+        let on_close = Closure::wrap(Box::new(move |e: web_sys::CloseEvent| {
+            log::info!(
+                "WebSocket closed: code={}, reason={}",
+                e.code(),
+                e.reason()
+            );
+        }) as Box<dyn FnMut(web_sys::CloseEvent)>);
+
+        ws.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
+        ws.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        ws.set_onclose(Some(on_close.as_ref().unchecked_ref()));
+
+        Ok(Self {
+            ws,
+            _on_message: on_message,
+            _on_error: on_error,
+            _on_close: on_close,
+        })
+    }
+
+    /// Send PTY data to the server.
+    pub fn send_pty_data(&self, data: &[u8]) {
+        let mut msg = Vec::with_capacity(1 + data.len());
+        msg.push(MSG_PTY_DATA);
+        msg.extend_from_slice(data);
+        let _ = self.ws.send_with_u8_array(&msg);
+    }
+
+    /// Send a resize message to the server.
+    pub fn send_resize(&self, cols: u16, rows: u16, cell_w: u16, cell_h: u16) {
+        let mut msg = Vec::with_capacity(9);
+        msg.push(MSG_RESIZE);
+        msg.extend_from_slice(&cols.to_le_bytes());
+        msg.extend_from_slice(&rows.to_le_bytes());
+        msg.extend_from_slice(&cell_w.to_le_bytes());
+        msg.extend_from_slice(&cell_h.to_le_bytes());
+        let _ = self.ws.send_with_u8_array(&msg);
+    }
+}
+
+impl Drop for WsConnection {
+    fn drop(&mut self) {
+        let _ = self.ws.close();
+    }
+}

--- a/demo/build.sh
+++ b/demo/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build the WASM package and set up the demo site.
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Building alacritty_web WASM package..."
+cd "$PROJECT_DIR/alacritty_web"
+wasm-pack build --target web
+
+echo "Copying pkg to demo directory..."
+rm -rf "$SCRIPT_DIR/pkg"
+cp -r "$PROJECT_DIR/alacritty_web/pkg" "$SCRIPT_DIR/pkg"
+
+echo "Done! Serve the demo directory with any HTTP server, e.g.:"
+echo "  cd $SCRIPT_DIR && python3 -m http.server 8080"

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Alacritty Web Terminal</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            background: #1d1f21;
+            color: #c5c8c6;
+            font-family: system-ui, -apple-system, sans-serif;
+            height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        #status-bar {
+            height: 32px;
+            background: #282a2e;
+            display: flex;
+            align-items: center;
+            padding: 0 12px;
+            font-size: 13px;
+            border-bottom: 1px solid #373b41;
+            flex-shrink: 0;
+        }
+
+        #status-indicator {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            margin-right: 8px;
+            background: #969896;
+            transition: background 0.3s;
+        }
+
+        #status-indicator.connected {
+            background: #b5bd68;
+        }
+
+        #status-indicator.error {
+            background: #cc6666;
+        }
+
+        #status-text {
+            color: #969896;
+        }
+
+        #terminal-container {
+            flex: 1;
+            position: relative;
+            overflow: hidden;
+        }
+
+        #terminal-canvas {
+            width: 100%;
+            height: 100%;
+            display: block;
+        }
+
+        #connect-form {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: #282a2e;
+            padding: 24px;
+            border-radius: 8px;
+            border: 1px solid #373b41;
+            text-align: center;
+        }
+
+        #connect-form h2 {
+            margin-bottom: 16px;
+            font-weight: 400;
+            font-size: 18px;
+        }
+
+        #connect-form input {
+            background: #1d1f21;
+            border: 1px solid #373b41;
+            color: #c5c8c6;
+            padding: 8px 12px;
+            border-radius: 4px;
+            font-size: 14px;
+            width: 300px;
+            margin-bottom: 12px;
+        }
+
+        #connect-form button {
+            background: #373b41;
+            color: #c5c8c6;
+            border: 1px solid #4d5057;
+            padding: 8px 24px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+        }
+
+        #connect-form button:hover {
+            background: #4d5057;
+        }
+    </style>
+</head>
+<body>
+    <div id="status-bar">
+        <div id="status-indicator"></div>
+        <span id="status-text">Disconnected</span>
+    </div>
+
+    <div id="terminal-container">
+        <canvas id="terminal-canvas" tabindex="0"></canvas>
+
+        <div id="connect-form">
+            <h2>Alacritty Web Terminal</h2>
+            <div>
+                <input type="text" id="ws-url" value="ws://127.0.0.1:7681" placeholder="WebSocket URL">
+            </div>
+            <button id="connect-btn">Connect</button>
+        </div>
+    </div>
+
+    <script type="module">
+        import init, { AlacrittyTerminal } from './pkg/alacritty_web.js';
+
+        let terminal = null;
+        const canvas = document.getElementById('terminal-canvas');
+        const statusIndicator = document.getElementById('status-indicator');
+        const statusText = document.getElementById('status-text');
+        const connectForm = document.getElementById('connect-form');
+        const connectBtn = document.getElementById('connect-btn');
+        const wsUrlInput = document.getElementById('ws-url');
+
+        function setStatus(state, text) {
+            statusIndicator.className = state;
+            statusText.textContent = text;
+        }
+
+        async function start() {
+            // Initialize WASM module.
+            await init();
+
+            // Create terminal (Canvas 2D renderer initializes synchronously).
+            try {
+                terminal = new AlacrittyTerminal(canvas);
+                setStatus('', 'Ready - enter URL and connect');
+            } catch (e) {
+                setStatus('error', 'Init failed: ' + e.message);
+                console.error('Init failed:', e);
+            }
+        }
+
+        connectBtn.addEventListener('click', () => {
+            const url = wsUrlInput.value.trim();
+            if (!url || !terminal) return;
+
+            try {
+                terminal.connect(url);
+                connectForm.style.display = 'none';
+                setStatus('connected', 'Connected to ' + url);
+                canvas.focus();
+            } catch (e) {
+                setStatus('error', 'Connection failed: ' + e.message);
+            }
+        });
+
+        wsUrlInput.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') connectBtn.click();
+        });
+
+        // Keyboard input -> terminal.
+        canvas.addEventListener('keydown', (e) => {
+            if (!terminal) return;
+
+            // Map key events to terminal byte sequences.
+            let bytes = null;
+
+            if (e.ctrlKey && e.key.length === 1) {
+                // Ctrl+letter -> control character.
+                const code = e.key.toUpperCase().charCodeAt(0) - 64;
+                if (code >= 0 && code <= 31) {
+                    bytes = new Uint8Array([code]);
+                }
+            } else if (e.key === 'Enter') {
+                bytes = new Uint8Array([13]);
+            } else if (e.key === 'Backspace') {
+                bytes = new Uint8Array([127]);
+            } else if (e.key === 'Tab') {
+                bytes = new Uint8Array([9]);
+            } else if (e.key === 'Escape') {
+                bytes = new Uint8Array([27]);
+            } else if (e.key === 'ArrowUp') {
+                bytes = new Uint8Array([27, 91, 65]);
+            } else if (e.key === 'ArrowDown') {
+                bytes = new Uint8Array([27, 91, 66]);
+            } else if (e.key === 'ArrowRight') {
+                bytes = new Uint8Array([27, 91, 67]);
+            } else if (e.key === 'ArrowLeft') {
+                bytes = new Uint8Array([27, 91, 68]);
+            } else if (e.key === 'Home') {
+                bytes = new Uint8Array([27, 91, 72]);
+            } else if (e.key === 'End') {
+                bytes = new Uint8Array([27, 91, 70]);
+            } else if (e.key === 'Delete') {
+                bytes = new Uint8Array([27, 91, 51, 126]);
+            } else if (e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
+                // Regular character input.
+                const encoded = new TextEncoder().encode(e.key);
+                bytes = encoded;
+            } else if (e.altKey && e.key.length === 1) {
+                // Alt+key -> ESC + key.
+                const encoded = new TextEncoder().encode(e.key);
+                bytes = new Uint8Array([27, ...encoded]);
+            }
+
+            if (bytes) {
+                e.preventDefault();
+                terminal.write(bytes);
+            }
+        });
+
+        // Handle canvas resize.
+        const resizeObserver = new ResizeObserver((entries) => {
+            if (!terminal) return;
+            const cellW = terminal.cell_width();
+            const cellH = terminal.cell_height();
+            if (cellW <= 0 || cellH <= 0) return;
+
+            for (const entry of entries) {
+                const { width, height } = entry.contentRect;
+                const cols = Math.floor(width / cellW);
+                const rows = Math.floor(height / cellH);
+                if (cols > 0 && rows > 0) {
+                    terminal.resize(cols, rows);
+                    console.log(`Resized to ${cols}x${rows} (${width}x${height}px)`);
+                }
+            }
+        });
+        resizeObserver.observe(canvas);
+
+        // Start.
+        start().catch(console.error);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **M1: `alacritty_terminal` compiles to `wasm32-unknown-unknown`** — Gate OS-specific code (`tty`, `event_loop`, `thread`, `sync::FairMutex`, `ExitStatus`) behind `cfg(not(target_arch = "wasm32"))`. Native compilation has zero regressions.
- **M2: WebSocket PTY server** (`alacritty_pty_server`) — Tokio + tokio-tungstenite + portable-pty. Binary protocol (0x00=data, 0x01=resize, 0x02=exit). CLI flags: `--bind`, `--port`, `--shell`, `--token`.
- **M3: WASM renderer** (`alacritty_web`) — Canvas 2D renderer (works in all browsers) with wgpu/WGSL skeleton for future GPU upgrade. Glyph rendering, color resolution (256-color + named), cursor display.
- **M4: Event loop + input** — RAF render loop with message queue pattern, WebSocket client wired to `alacritty_terminal` VTE parser, keyboard input mapping, resize handling.
- **M5: Demo website** (`demo/`) — Minimal HTML/JS page with status bar, connect form, keyboard forwarding.

## How to test

```bash
# Terminal 1: Start PTY server
cargo run -p alacritty_pty_server

# Terminal 2: Build and serve demo
cd alacritty_web && wasm-pack build --target web
cd ../demo && cp -r ../alacritty_web/pkg . && python3 -m http.server 8080

# Open http://localhost:8080 in browser, click Connect
```

## Test plan

- [x] `cargo check -p alacritty_terminal --target wasm32-unknown-unknown` passes
- [x] `cargo check -p alacritty` (native) still passes — no regressions
- [x] `cargo check -p alacritty_pty_server` passes
- [x] `wasm-pack build --target web` succeeds (~2MB WASM)
- [x] PTY server accepts WebSocket connections and spawns shells
- [x] Demo page renders terminal with colors, prompt, cursor
- [x] Keyboard input works (typing commands, ctrl+c, arrows)
- [ ] Test in Firefox
- [ ] Test resize behavior

Closes #2, #3, #4, #5, #6, #7, #9, #10, #11, #12, #13, #14, #15, #16, #17, #18, #19, #21, #22, #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)