### PR TITLE
Add WASM CI and wasm32 unit tests

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,78 @@
+name: WASM CI
+
+on:
+  push:
+    branches: [wasm]
+  pull_request:
+    branches: [wasm]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check-terminal-wasm:
+    name: Check alacritty_terminal (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+      - name: cargo check alacritty_terminal for wasm32
+        run: cargo check -p alacritty_terminal --target wasm32-unknown-unknown
+
+  check-web-wasm:
+    name: Check alacritty_web (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+      - name: cargo check alacritty_web for wasm32
+        run: cargo check -p alacritty_web --target wasm32-unknown-unknown
+
+  check-native:
+    name: Check alacritty (native)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake pkg-config libfreetype6-dev libfontconfig1-dev
+      - name: cargo check alacritty (native regression)
+        run: cargo check -p alacritty
+
+  wasm-pack-build:
+    name: wasm-pack build alacritty_web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: wasm-pack build
+        run: wasm-pack build --target web
+        working-directory: alacritty_web
+
+  wasm-tests:
+    name: WASM unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run WASM tests
+        run: wasm-pack test --node
+        working-directory: alacritty_terminal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "signal-hook",
  "unicode-width 0.2.2",
  "vte",
+ "wasm-bindgen-test",
  "windows-sys 0.59.0",
 ]
 

--- a/alacritty_terminal/Cargo.toml
+++ b/alacritty_terminal/Cargo.toml
@@ -48,3 +48,4 @@ windows-sys = { version = "0.59.0", features = [
 
 [dev-dependencies]
 serde_json = "1.0.0"
+wasm-bindgen-test = "0.3"

--- a/alacritty_terminal/tests/ref.rs
+++ b/alacritty_terminal/tests/ref.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "serde")]
+#![cfg(all(feature = "serde", not(target_arch = "wasm32")))]
 use serde::Deserialize;
 use serde_json as json;
 

--- a/alacritty_terminal/tests/wasm_tests.rs
+++ b/alacritty_terminal/tests/wasm_tests.rs
@@ -1,0 +1,133 @@
+//! WASM-specific tests for alacritty_terminal.
+//!
+//! These tests verify that core terminal functionality works correctly
+//! when compiled to wasm32. They run under wasm-pack test --node.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::sync::FairMutex;
+use alacritty_terminal::term::test::TermSize;
+use alacritty_terminal::term::{Config, Term};
+use alacritty_terminal::vte::ansi;
+
+/// A no-op event listener for tests.
+#[derive(Copy, Clone)]
+struct Mock;
+
+impl EventListener for Mock {
+    fn send_event(&self, _event: Event) {}
+}
+
+#[wasm_bindgen_test]
+fn term_new_on_wasm32() {
+    let size = TermSize::new(80, 24);
+    let term = Term::new(Config::default(), &size, Mock);
+
+    assert_eq!(term.grid().columns(), 80);
+    assert_eq!(term.grid().screen_lines(), 24);
+}
+
+#[wasm_bindgen_test]
+fn vte_parser_basic_escape_sequences() {
+    let size = TermSize::new(80, 24);
+    let mut term = Term::new(Config::default(), &size, Mock);
+    let mut parser = ansi::Processor::new();
+
+    // Feed "Hello" through the VTE parser.
+    let input = b"Hello";
+    parser.advance(&mut term, input);
+
+    // The cursor should have advanced 5 columns.
+    let cursor = term.grid().cursor.point;
+    assert_eq!(cursor.column.0, 5);
+    assert_eq!(cursor.line.0, 0);
+}
+
+#[wasm_bindgen_test]
+fn vte_parser_csi_cursor_movement() {
+    let size = TermSize::new(80, 24);
+    let mut term = Term::new(Config::default(), &size, Mock);
+    let mut parser = ansi::Processor::new();
+
+    // Write text, then use CSI sequence to move cursor to position (1,1).
+    // ESC [ H moves cursor to home (0,0 in 0-indexed).
+    let input = b"Hello\x1b[H";
+    parser.advance(&mut term, input);
+
+    let cursor = term.grid().cursor.point;
+    assert_eq!(cursor.column.0, 0);
+    assert_eq!(cursor.line.0, 0);
+}
+
+#[wasm_bindgen_test]
+fn fair_mutex_lock_unlock() {
+    let mutex = FairMutex::new(42u32);
+
+    // Lock and read value.
+    {
+        let guard = mutex.lock();
+        assert_eq!(*guard, 42);
+    }
+
+    // Lock and mutate value.
+    {
+        let mut guard = mutex.lock();
+        *guard = 100;
+    }
+
+    // Verify mutation persisted.
+    {
+        let guard = mutex.lock();
+        assert_eq!(*guard, 100);
+    }
+}
+
+#[wasm_bindgen_test]
+fn terminal_resize() {
+    let size = TermSize::new(80, 24);
+    let mut term = Term::new(Config::default(), &size, Mock);
+
+    assert_eq!(term.grid().columns(), 80);
+    assert_eq!(term.grid().screen_lines(), 24);
+
+    // Resize the terminal.
+    let new_size = TermSize::new(120, 40);
+    term.resize(new_size);
+
+    assert_eq!(term.grid().columns(), 120);
+    assert_eq!(term.grid().screen_lines(), 40);
+}
+
+#[wasm_bindgen_test]
+fn vte_parser_newline_handling() {
+    let size = TermSize::new(80, 24);
+    let mut term = Term::new(Config::default(), &size, Mock);
+    let mut parser = ansi::Processor::new();
+
+    // Write text with newlines (LF moves cursor down, CR returns to column 0).
+    let input = b"Line1\r\nLine2";
+    parser.advance(&mut term, input);
+
+    let cursor = term.grid().cursor.point;
+    assert_eq!(cursor.line.0, 1);
+    assert_eq!(cursor.column.0, 5); // "Line2" is 5 chars.
+}
+
+#[wasm_bindgen_test]
+fn terminal_clear_screen() {
+    let size = TermSize::new(80, 24);
+    let mut term = Term::new(Config::default(), &size, Mock);
+    let mut parser = ansi::Processor::new();
+
+    // Write some text then clear screen (CSI 2 J) and go home (CSI H).
+    let input = b"Hello World\x1b[2J\x1b[H";
+    parser.advance(&mut term, input);
+
+    let cursor = term.grid().cursor.point;
+    assert_eq!(cursor.column.0, 0);
+    assert_eq!(cursor.line.0, 0);
+}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/wasm.yml` with CI jobs for wasm32 compilation checks, native regression check, wasm-pack build, and WASM unit tests (closes #8)
- Add `alacritty_terminal/tests/wasm_tests.rs` with wasm32-specific unit tests covering Term::new, VTE parser, FairMutex, terminal resize, newline handling, and screen clear (closes #25)
- Gate existing ref tests with `#[cfg(not(target_arch = "wasm32"))]` to avoid filesystem-dependent tests on WASM
- Add `wasm-bindgen-test` dev-dependency to `alacritty_terminal`

## CI Jobs
1. **check-terminal-wasm** - `cargo check -p alacritty_terminal --target wasm32-unknown-unknown`
2. **check-web-wasm** - `cargo check -p alacritty_web --target wasm32-unknown-unknown`
3. **check-native** - `cargo check -p alacritty` (native regression)
4. **wasm-pack-build** - `wasm-pack build --target web` in `alacritty_web/`
5. **wasm-tests** - `wasm-pack test --node` in `alacritty_terminal/`

## Test plan
- [ ] Verify CI workflow triggers on push/PR to `wasm` branch
- [ ] Verify all five CI jobs pass
- [ ] Verify WASM unit tests pass under `wasm-pack test --node`
- [ ] Verify existing native tests still pass (`cargo test -p alacritty_terminal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)