### PR TITLE
Public wasm-bindgen API and npm package build pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,8 @@ dependencies = [
  "console_log",
  "js-sys",
  "log",
+ "serde",
+ "serde-wasm-bindgen",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -2392,6 +2394,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/alacritty_web/.gitignore
+++ b/alacritty_web/.gitignore
@@ -1,0 +1,2 @@
+pkg/
+node_modules/

--- a/alacritty_web/Cargo.toml
+++ b/alacritty_web/Cargo.toml
@@ -49,6 +49,8 @@ bytemuck = { version = "1", features = ["derive"] }
 log = "0.4"
 console_log = "1"
 console_error_panic_hook = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.6"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/alacritty_web/build-npm.sh
+++ b/alacritty_web/build-npm.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Build the @alacritty/web npm package using wasm-pack.
+#
+# Usage:
+#   bash build-npm.sh          # default build
+#   bash build-npm.sh --release # release (optimized) build
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Check for wasm-pack
+if ! command -v wasm-pack &>/dev/null; then
+  echo "Error: wasm-pack is not installed."
+  echo "Install it with: cargo install wasm-pack"
+  exit 1
+fi
+
+echo "==> Building alacritty_web with wasm-pack..."
+wasm-pack build --target web --out-dir pkg "$@"
+
+# Patch the generated package.json with our metadata.
+# wasm-pack generates its own package.json in pkg/; we overwrite the key fields
+# so that the published package has the correct name, version, and entry points.
+echo "==> Patching pkg/package.json..."
+
+# Read version from the root package.json
+VERSION=$(python3 -c "import json; print(json.load(open('package.json'))['version'])" 2>/dev/null || echo "0.1.0")
+
+# Use node if available, otherwise python3, to patch the generated package.json
+if command -v node &>/dev/null; then
+  node -e "
+    const fs = require('fs');
+    const pkg = JSON.parse(fs.readFileSync('pkg/package.json', 'utf8'));
+    pkg.name = '@alacritty/web';
+    pkg.version = '${VERSION}';
+    pkg.description = 'Alacritty terminal emulator for the browser via WebAssembly';
+    pkg.license = 'Apache-2.0';
+    pkg.repository = {
+      type: 'git',
+      url: 'https://github.com/alacritty/alacritty.git',
+      directory: 'alacritty_web'
+    };
+    pkg.keywords = ['terminal', 'alacritty', 'wasm', 'webassembly', 'canvas'];
+    fs.writeFileSync('pkg/package.json', JSON.stringify(pkg, null, 2) + '\n');
+  "
+elif command -v python3 &>/dev/null; then
+  python3 -c "
+import json, pathlib
+p = pathlib.Path('pkg/package.json')
+pkg = json.loads(p.read_text())
+pkg['name'] = '@alacritty/web'
+pkg['version'] = '${VERSION}'
+pkg['description'] = 'Alacritty terminal emulator for the browser via WebAssembly'
+pkg['license'] = 'Apache-2.0'
+pkg['repository'] = {
+    'type': 'git',
+    'url': 'https://github.com/alacritty/alacritty.git',
+    'directory': 'alacritty_web'
+}
+pkg['keywords'] = ['terminal', 'alacritty', 'wasm', 'webassembly', 'canvas']
+p.write_text(json.dumps(pkg, indent=2) + '\n')
+  "
+else
+  echo "Warning: Neither node nor python3 available; pkg/package.json not patched."
+fi
+
+echo "==> Build complete. Output in pkg/"
+echo ""
+echo "Package contents:"
+ls -lh pkg/*.js pkg/*.d.ts pkg/*.wasm 2>/dev/null || true

--- a/alacritty_web/package.json
+++ b/alacritty_web/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@alacritty/web",
+  "version": "0.1.0",
+  "description": "Alacritty terminal emulator for the browser via WebAssembly",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alacritty/alacritty.git",
+    "directory": "alacritty_web"
+  },
+  "main": "pkg/alacritty_web.js",
+  "module": "pkg/alacritty_web.js",
+  "types": "pkg/alacritty_web.d.ts",
+  "files": [
+    "pkg/alacritty_web.js",
+    "pkg/alacritty_web.d.ts",
+    "pkg/alacritty_web_bg.wasm"
+  ],
+  "sideEffects": [
+    "pkg/alacritty_web.js"
+  ],
+  "keywords": [
+    "terminal",
+    "alacritty",
+    "wasm",
+    "webassembly",
+    "canvas"
+  ],
+  "scripts": {
+    "build": "bash build-npm.sh",
+    "prepublishOnly": "npm run build"
+  }
+}

--- a/alacritty_web/src/lib.rs
+++ b/alacritty_web/src/lib.rs
@@ -7,8 +7,44 @@ mod websocket;
 use std::cell::RefCell;
 use std::rc::Rc;
 
+use serde::Deserialize;
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
+
+/// Configuration passed from JavaScript.
+///
+/// Accepted as a JS object:
+/// ```js
+/// { fontSize: 14, fontFamily: "monospace", theme: "dark" }
+/// ```
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct TerminalConfig {
+    #[serde(default = "default_font_size")]
+    font_size: f32,
+    #[serde(default = "default_font_family")]
+    font_family: String,
+    #[serde(default)]
+    theme: Option<String>,
+}
+
+fn default_font_size() -> f32 {
+    14.0
+}
+
+fn default_font_family() -> String {
+    "'Fira Code', 'Cascadia Code', 'Source Code Pro', monospace".to_string()
+}
+
+impl Default for TerminalConfig {
+    fn default() -> Self {
+        Self {
+            font_size: default_font_size(),
+            font_family: default_font_family(),
+            theme: None,
+        }
+    }
+}
 
 /// Initialize panic hook and logger for better WASM debugging.
 fn init_wasm() {
@@ -36,12 +72,31 @@ pub struct AlacrittyTerminal {
 #[wasm_bindgen]
 impl AlacrittyTerminal {
     /// Create a new terminal attached to the given canvas element.
+    ///
+    /// The optional `config` parameter accepts a JS object:
+    /// ```js
+    /// { fontSize: 14, fontFamily: "monospace", theme: "dark" }
+    /// ```
     #[wasm_bindgen(constructor)]
-    pub fn new(canvas: HtmlCanvasElement) -> Result<AlacrittyTerminal, JsError> {
+    pub fn new(canvas: HtmlCanvasElement, config: JsValue) -> Result<AlacrittyTerminal, JsError> {
         init_wasm();
         log::info!("Initializing AlacrittyTerminal");
 
-        let renderer = renderer::canvas2d::Canvas2dRenderer::new(&canvas)?;
+        let cfg: TerminalConfig = if config.is_undefined() || config.is_null() {
+            TerminalConfig::default()
+        } else {
+            serde_wasm_bindgen::from_value(config)
+                .map_err(|e| JsError::new(&format!("Invalid config: {e}")))?
+        };
+
+        log::info!("Config: {cfg:?}");
+
+        let mut renderer = renderer::canvas2d::Canvas2dRenderer::new(&canvas)?;
+
+        // Apply config to renderer.
+        renderer.set_font_size(cfg.font_size);
+        renderer.set_font_family(&cfg.font_family);
+
         let cell_w = renderer.cell_width();
         let cell_h = renderer.cell_height();
 
@@ -97,13 +152,33 @@ impl AlacrittyTerminal {
         }
     }
 
-    /// Send a resize message to the server.
+    /// Send a resize message to the server and update the terminal grid.
     pub fn resize(&mut self, cols: u16, rows: u16) {
         self.state.borrow_mut().terminal.resize(cols, rows);
         self.state.borrow_mut().dirty = true;
         if let Some(ws) = &self.ws {
             ws.send_resize(cols, rows, 0, 0);
         }
+    }
+
+    /// Focus the canvas element.
+    pub fn focus(&self) {
+        let html_element: &web_sys::HtmlElement = self.canvas.as_ref();
+        let _ = html_element.focus();
+    }
+
+    /// Set the font size in pixels and trigger a re-render.
+    pub fn set_font_size(&self, size_px: f32) {
+        let mut app = self.state.borrow_mut();
+        app.renderer.set_font_size(size_px);
+        app.dirty = true;
+    }
+
+    /// Set the font family and trigger a re-render.
+    pub fn set_font_family(&self, family: &str) {
+        let mut app = self.state.borrow_mut();
+        app.renderer.set_font_family(family);
+        app.dirty = true;
     }
 
     /// Get cell width in pixels.
@@ -114,6 +189,24 @@ impl AlacrittyTerminal {
     /// Get cell height in pixels.
     pub fn cell_height(&self) -> f32 {
         self.state.borrow().renderer.cell_height()
+    }
+
+    /// Get the number of columns in the terminal grid.
+    pub fn cols(&self) -> u16 {
+        self.state.borrow().terminal.cols()
+    }
+
+    /// Get the number of rows in the terminal grid.
+    pub fn rows(&self) -> u16 {
+        self.state.borrow().terminal.rows()
+    }
+
+    /// Feed raw bytes into the terminal as if received from a PTY.
+    ///
+    /// This is useful for demos, replays, or custom data sources that
+    /// bypass the WebSocket connection.
+    pub fn feed(&self, data: &[u8]) {
+        self.incoming_data.borrow_mut().push(data.to_vec());
     }
 
     /// Clean up resources.

--- a/alacritty_web/src/renderer/canvas2d.rs
+++ b/alacritty_web/src/renderer/canvas2d.rs
@@ -84,7 +84,7 @@ impl Canvas2dRenderer {
         let num_lines = term.screen_lines();
 
         let bg_color = colors::default_named_color(NamedColor::Background);
-        let fg_default = colors::default_named_color(NamedColor::Foreground);
+        let _fg_default = colors::default_named_color(NamedColor::Foreground);
 
         let cw = self.cell_width as f64;
         let ch = self.cell_height as f64;
@@ -198,6 +198,28 @@ impl Canvas2dRenderer {
     /// Cell height in pixels.
     pub fn cell_height(&self) -> f32 {
         self.cell_height
+    }
+
+    /// Set the font size and remeasure cell dimensions.
+    pub fn set_font_size(&mut self, size_px: f32) {
+        self.font_size_px = size_px;
+        self.remeasure_cells();
+    }
+
+    /// Set the font family and remeasure cell dimensions.
+    pub fn set_font_family(&mut self, family: &str) {
+        self.font_family = family.to_string();
+        self.remeasure_cells();
+    }
+
+    /// Remeasure cell dimensions after font changes.
+    fn remeasure_cells(&mut self) {
+        let font_str = format!("{}px {}", self.font_size_px, self.font_family);
+        self.ctx.set_font(&font_str);
+        if let Ok(metrics) = self.ctx.measure_text("M") {
+            self.cell_width = metrics.width() as f32;
+            self.cell_height = (self.font_size_px * 1.4_f32).ceil();
+        }
     }
 
     /// Resize the canvas.

--- a/alacritty_web/src/terminal.rs
+++ b/alacritty_web/src/terminal.rs
@@ -96,4 +96,16 @@ impl WebTerminal {
     pub fn term(&self) -> &Rc<FairMutex<Term<WebEventProxy>>> {
         &self.term
     }
+
+    /// Get the number of columns in the terminal grid.
+    pub fn cols(&self) -> u16 {
+        let term = self.term.lock();
+        term.columns() as u16
+    }
+
+    /// Get the number of rows in the terminal grid.
+    pub fn rows(&self) -> u16 {
+        let term = self.term.lock();
+        term.screen_lines() as u16
+    }
 }


### PR DESCRIPTION
## Summary
- Clean up `AlacrittyTerminal` public API with config support (`JsValue` parsed via `serde-wasm-bindgen`), `focus()`, `set_font_size()`, `set_font_family()`, `cols()`, `rows()` methods
- Add `Canvas2dRenderer` methods for runtime font size/family changes with automatic cell remeasuring
- Create `@alacritty/web` npm package with `package.json` and `build-npm.sh` (wraps `wasm-pack build --target web`)

## Test plan
- [ ] Verify `cargo check -p alacritty_web --target wasm32-unknown-unknown` compiles cleanly
- [ ] Run `bash alacritty_web/build-npm.sh` to confirm wasm-pack produces `.js`, `.d.ts`, and `.wasm` files in `pkg/`
- [ ] Test constructor with config: `new AlacrittyTerminal(canvas, { fontSize: 16, fontFamily: "monospace" })`
- [ ] Test constructor with no config: `new AlacrittyTerminal(canvas)` (defaults apply)
- [ ] Verify `cols()`, `rows()`, `cell_width()`, `cell_height()` return correct values
- [ ] Verify `set_font_size()` and `set_font_family()` update the renderer and trigger re-render

Closes #22, closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)