### PR TITLE
Fix security vulnerabilities and bugs (#31)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ members = [
     "alacritty_pty_server",
     "alacritty_web",
 ]
+default-members = [
+    "alacritty",
+    "alacritty_terminal",
+    "alacritty_config",
+    "alacritty_config_derive",
+    "alacritty_pty_server",
+]
 resolver = "2"
 
 [workspace.package]

--- a/alacritty_pty_server/src/main.rs
+++ b/alacritty_pty_server/src/main.rs
@@ -28,6 +28,12 @@ pub struct Args {
     /// When set, the client must send this token as its first WebSocket message.
     #[arg(long)]
     token: Option<String>,
+
+    /// Allowed origins for WebSocket connections (repeatable).
+    /// When set, only connections with a matching Origin header are accepted.
+    /// When not set, only same-origin (no Origin header) connections are allowed.
+    #[arg(long = "allowed-origin")]
+    allowed_origins: Vec<String>,
 }
 
 impl Args {

--- a/alacritty_pty_server/src/protocol.rs
+++ b/alacritty_pty_server/src/protocol.rs
@@ -5,9 +5,16 @@
 /// - `0x01` + 4x u16 LE      = resize (client -> server): cols, rows, cell_w, cell_h
 /// - `0x02` + optional u8     = child exited (server -> client), with optional exit code
 
+use log::warn;
+
 pub const MSG_DATA: u8 = 0x00;
 pub const MSG_RESIZE: u8 = 0x01;
 pub const MSG_EXIT: u8 = 0x02;
+
+/// Maximum allowed columns for resize requests.
+const MAX_COLS: u16 = 500;
+/// Maximum allowed rows for resize requests.
+const MAX_ROWS: u16 = 200;
 
 /// A parsed message from the client.
 #[derive(Debug)]
@@ -36,10 +43,22 @@ pub fn parse_client_message(data: &[u8]) -> Option<ClientMessage> {
                 // Need 1 byte tag + 4 * 2 bytes = 9 bytes total.
                 return None;
             }
-            let cols = u16::from_le_bytes([data[1], data[2]]);
-            let rows = u16::from_le_bytes([data[3], data[4]]);
+            let raw_cols = u16::from_le_bytes([data[1], data[2]]);
+            let raw_rows = u16::from_le_bytes([data[3], data[4]]);
             let cell_w = u16::from_le_bytes([data[5], data[6]]);
             let cell_h = u16::from_le_bytes([data[7], data[8]]);
+
+            // Clamp cols to 1..=500 and rows to 1..=200.
+            let cols = raw_cols.clamp(1, MAX_COLS);
+            let rows = raw_rows.clamp(1, MAX_ROWS);
+
+            if cols != raw_cols || rows != raw_rows {
+                warn!(
+                    "Resize values out of range: cols={} (clamped to {}), rows={} (clamped to {})",
+                    raw_cols, cols, raw_rows, rows
+                );
+            }
+
             Some(ClientMessage::Resize {
                 cols,
                 rows,

--- a/alacritty_pty_server/src/session.rs
+++ b/alacritty_pty_server/src/session.rs
@@ -13,6 +13,27 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 use crate::Args;
 use crate::protocol::{self, ClientMessage};
 
+/// Check whether the Origin header is allowed based on the configured allowed origins.
+/// If no allowed origins are configured, only requests without an Origin header are accepted
+/// (same-origin policy).
+fn is_origin_allowed(origin: Option<&http::HeaderValue>, allowed_origins: &[String]) -> bool {
+    match origin {
+        None => {
+            // No Origin header means same-origin; always allowed.
+            true
+        }
+        Some(origin_value) => {
+            if allowed_origins.is_empty() {
+                // No allowed origins configured: reject cross-origin requests.
+                false
+            } else {
+                let origin_str = origin_value.to_str().unwrap_or("");
+                allowed_origins.iter().any(|allowed| allowed == origin_str)
+            }
+        }
+    }
+}
+
 /// Handle a single TCP connection: upgrade to WebSocket, optionally authenticate,
 /// spawn a PTY, and bridge I/O.
 pub async fn handle_connection(
@@ -20,17 +41,39 @@ pub async fn handle_connection(
     peer: SocketAddr,
     args: Arc<Args>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // WebSocket upgrade with CORS headers.
-    let ws_stream = tokio_tungstenite::accept_hdr_async(stream, |req: &Request, mut resp: Response| {
-        // Add CORS header for the demo website.
-        resp.headers_mut().insert(
-            http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
-            http::HeaderValue::from_static("*"),
-        );
-        let _ = req;
-        Ok(resp)
-    })
-    .await?;
+    let allowed_origins = args.allowed_origins.clone();
+
+    // WebSocket upgrade with origin validation.
+    let ws_stream =
+        tokio_tungstenite::accept_hdr_async(stream, |req: &Request, mut resp: Response| {
+            let origin = req.headers().get(http::header::ORIGIN);
+
+            if !is_origin_allowed(origin, &allowed_origins) {
+                let origin_str = origin
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or("<unknown>");
+                warn!(
+                    "Rejected connection from {}: origin '{}' not allowed",
+                    peer, origin_str
+                );
+                *resp.status_mut() = http::StatusCode::FORBIDDEN;
+                return Err(http::Response::builder()
+                    .status(http::StatusCode::FORBIDDEN)
+                    .body(Some("Origin not allowed".to_string()))
+                    .unwrap());
+            }
+
+            // If origin is allowed and present, echo it back in CORS header.
+            if let Some(origin_value) = origin {
+                resp.headers_mut().insert(
+                    http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
+                    origin_value.clone(),
+                );
+            }
+
+            Ok(resp)
+        })
+        .await?;
 
     info!("WebSocket connection established with {}", peer);
 
@@ -43,18 +86,27 @@ pub async fn handle_connection(
             Some(Ok(Message::Text(token))) => {
                 if token.trim() != expected_token.as_str() {
                     warn!("Auth failed from {}: invalid token", peer);
-                    let _ = ws_sink
-                        .send(Message::Close(None))
-                        .await;
+                    if let Err(e) = ws_sink.send(Message::Close(None)).await {
+                        warn!(
+                            "Failed to send close after auth failure to {}: {}",
+                            peer, e
+                        );
+                    }
                     return Ok(());
                 }
                 info!("Auth succeeded for {}", peer);
             }
             _ => {
-                warn!("Auth failed from {}: expected text message with token", peer);
-                let _ = ws_sink
-                    .send(Message::Close(None))
-                    .await;
+                warn!(
+                    "Auth failed from {}: expected text message with token",
+                    peer
+                );
+                if let Err(e) = ws_sink.send(Message::Close(None)).await {
+                    warn!(
+                        "Failed to send close after auth failure to {}: {}",
+                        peer, e
+                    );
+                }
                 return Ok(());
             }
         }
@@ -77,10 +129,13 @@ pub async fn handle_connection(
     let mut cmd = CommandBuilder::new(&shell);
     cmd.env("TERM", "xterm-256color");
 
-    let mut child = pair
+    let child = pair
         .slave
         .spawn_command(cmd)
         .map_err(|e| format!("Failed to spawn shell '{}': {}", shell, e))?;
+
+    // Wrap child in Arc<Mutex> so we can kill it on WebSocket close.
+    let child = Arc::new(std::sync::Mutex::new(child));
 
     // Drop the slave side - the child has it.
     drop(pair.slave);
@@ -107,7 +162,10 @@ pub async fn handle_connection(
                 Ok(0) => break,
                 Ok(n) => {
                     let msg = protocol::encode_data(&buf[..n]);
-                    if ws_tx_pty.blocking_send(Message::Binary(msg.into())).is_err() {
+                    if ws_tx_pty
+                        .blocking_send(Message::Binary(msg.into()))
+                        .is_err()
+                    {
                         break;
                     }
                 }
@@ -125,11 +183,14 @@ pub async fn handle_connection(
     // Task 2: Forward channel messages to WebSocket sink.
     let ws_write_handle = tokio::spawn(async move {
         while let Some(msg) = ws_rx.recv().await {
-            if ws_sink.send(msg).await.is_err() {
+            if let Err(e) = ws_sink.send(msg).await {
+                warn!("WebSocket send error: {}", e);
                 break;
             }
         }
-        let _ = ws_sink.close().await;
+        if let Err(e) = ws_sink.close().await {
+            warn!("WebSocket close error: {}", e);
+        }
     });
 
     // Task 3: Read from WebSocket and write to PTY / handle resize.
@@ -146,11 +207,16 @@ pub async fn handle_connection(
                             match client_msg {
                                 ClientMessage::Data(payload) => {
                                     let writer = Arc::clone(&writer);
-                                    let _ = tokio::task::spawn_blocking(move || {
+                                    if let Err(e) = tokio::task::spawn_blocking(move || {
                                         let mut w = writer.lock().unwrap();
-                                        let _ = w.write_all(&payload);
+                                        if let Err(e) = w.write_all(&payload) {
+                                            error!("PTY write error: {}", e);
+                                        }
                                     })
-                                    .await;
+                                    .await
+                                    {
+                                        error!("PTY write task failed: {}", e);
+                                    }
                                 }
                                 ClientMessage::Resize {
                                     cols,
@@ -159,7 +225,7 @@ pub async fn handle_connection(
                                     cell_h,
                                 } => {
                                     let master = Arc::clone(&master);
-                                    let _ = tokio::task::spawn_blocking(move || {
+                                    if let Err(e) = tokio::task::spawn_blocking(move || {
                                         let m = master.lock().unwrap();
                                         let size = PtySize {
                                             rows,
@@ -176,7 +242,10 @@ pub async fn handle_connection(
                                             );
                                         }
                                     })
-                                    .await;
+                                    .await
+                                    {
+                                        error!("PTY resize task failed: {}", e);
+                                    }
                                 }
                             }
                         }
@@ -199,15 +268,14 @@ pub async fn handle_connection(
 
     // Task 4: Wait for child to exit and send exit notification.
     let ws_tx_exit = ws_tx.clone();
+    let child_for_wait = Arc::clone(&child);
     let child_wait_handle = tokio::task::spawn_blocking(move || {
-        let status = child.wait();
+        let status = child_for_wait.lock().unwrap().wait();
         let exit_code = match status {
             Ok(status) => {
                 if status.success() {
                     Some(0u8)
                 } else {
-                    // portable-pty ExitStatus doesn't expose the raw code easily,
-                    // so we use 1 for failure.
                     Some(1u8)
                 }
             }
@@ -215,7 +283,9 @@ pub async fn handle_connection(
         };
         info!("Child exited with code: {:?}", exit_code);
         let msg = protocol::encode_exit(exit_code);
-        let _ = ws_tx_exit.blocking_send(Message::Binary(msg.into()));
+        if let Err(e) = ws_tx_exit.blocking_send(Message::Binary(msg.into())) {
+            warn!("Failed to send exit notification: {}", e);
+        }
     });
 
     // Wait for the child to exit or the WebSocket read to finish.
@@ -225,15 +295,30 @@ pub async fn handle_connection(
         }
         _ = ws_read_handle => {
             info!("WebSocket closed by client {}", peer);
+            // Kill the child process if still running.
+            let child_for_kill = Arc::clone(&child);
+            if let Err(e) = tokio::task::spawn_blocking(move || {
+                let mut child = child_for_kill.lock().unwrap();
+                info!("Killing child process after WebSocket close");
+                if let Err(e) = child.kill() {
+                    warn!("Failed to kill child process: {}", e);
+                }
+            }).await {
+                error!("Child kill task failed: {}", e);
+            }
         }
     }
 
     // Clean up: wait briefly for remaining data to flush.
-    let _ = pty_read_handle.await;
+    if let Err(e) = pty_read_handle.await {
+        warn!("PTY read task join error: {}", e);
+    }
 
     // Drop the sender so the write task finishes.
     drop(ws_tx);
-    let _ = ws_write_handle.await;
+    if let Err(e) = ws_write_handle.await {
+        warn!("WebSocket write task join error: {}", e);
+    }
 
     info!("Session ended for {}", peer);
     Ok(())

--- a/alacritty_web/src/lib.rs
+++ b/alacritty_web/src/lib.rs
@@ -10,6 +10,12 @@ use std::rc::Rc;
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
 
+/// Font configuration for the terminal renderer, matching `FontConfig` in `canvas2d.rs`.
+///
+/// All fields have sensible defaults so the struct can be constructed with just
+/// `FontConfig::default()`.
+pub use renderer::canvas2d::FontConfig;
+
 /// Initialize panic hook and logger for better WASM debugging.
 fn init_wasm() {
     console_error_panic_hook::set_once();
@@ -76,11 +82,16 @@ impl AlacrittyTerminal {
 
     /// Connect to a WebSocket PTY server.
     pub fn connect(&mut self, ws_url: &str) -> Result<(), JsError> {
-        // WebSocket data goes into the queue, not directly into the terminal.
         let queue = self.incoming_data.clone();
-        let ws = websocket::WsConnection::new(ws_url, move |data| {
-            queue.borrow_mut().push(data.to_vec());
-        })?;
+        let ws = websocket::WsConnection::new(
+            ws_url,
+            || {
+                log::info!("WebSocket connection ready");
+            },
+            move |data| {
+                queue.borrow_mut().push(data.to_vec());
+            },
+        )?;
         self.ws = Some(ws);
         Ok(())
     }
@@ -114,6 +125,27 @@ impl AlacrittyTerminal {
     /// Get cell height in pixels.
     pub fn cell_height(&self) -> f32 {
         self.state.borrow().renderer.cell_height()
+    }
+
+    /// Set the font size in pixels and trigger a re-render.
+    pub fn set_font_size(&self, size_px: f32) {
+        let mut app = self.state.borrow_mut();
+        app.renderer.set_font_size(size_px);
+        app.dirty = true;
+    }
+
+    /// Set the font family and trigger a re-render.
+    pub fn set_font_family(&self, family: &str) {
+        let mut app = self.state.borrow_mut();
+        app.renderer.set_font_family(family);
+        app.dirty = true;
+    }
+
+    /// Set the line height multiplier and trigger a re-render.
+    pub fn set_line_height_multiplier(&self, multiplier: f32) {
+        let mut app = self.state.borrow_mut();
+        app.renderer.set_line_height_multiplier(multiplier);
+        app.dirty = true;
     }
 
     /// Clean up resources.

--- a/alacritty_web/src/renderer/canvas2d.rs
+++ b/alacritty_web/src/renderer/canvas2d.rs
@@ -14,19 +14,39 @@ use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
 use super::colors;
 use crate::terminal::WebEventProxy;
 
+/// Font configuration for the Canvas 2D renderer.
+#[derive(Debug, Clone)]
+pub struct FontConfig {
+    /// Font family CSS string (e.g. "'Fira Code', monospace").
+    pub family: String,
+    /// Font size in CSS pixels.
+    pub size_px: f32,
+    /// Line height multiplier (cell height = font_size * line_height_multiplier).
+    pub line_height_multiplier: f32,
+}
+
+impl Default for FontConfig {
+    fn default() -> Self {
+        Self {
+            family: "'Fira Code', 'Cascadia Code', 'Source Code Pro', monospace".to_string(),
+            size_px: 14.0,
+            line_height_multiplier: 1.4,
+        }
+    }
+}
+
 /// Canvas 2D-based terminal renderer.
 pub struct Canvas2dRenderer {
     canvas: HtmlCanvasElement,
     ctx: CanvasRenderingContext2d,
-    font_family: String,
-    font_size_px: f32,
+    font_config: FontConfig,
     cell_width: f32,
     cell_height: f32,
     device_pixel_ratio: f64,
 }
 
 impl Canvas2dRenderer {
-    /// Create a new Canvas 2D renderer.
+    /// Create a new Canvas 2D renderer with default font configuration.
     pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsError> {
         let ctx = canvas
             .get_context("2d")
@@ -35,18 +55,17 @@ impl Canvas2dRenderer {
             .dyn_into::<CanvasRenderingContext2d>()
             .map_err(|_| JsError::new("Not a CanvasRenderingContext2d"))?;
 
-        let font_family = "'Fira Code', 'Cascadia Code', 'Source Code Pro', monospace".to_string();
-        let font_size_px = 14.0;
+        let font_config = FontConfig::default();
 
         // Measure cell dimensions.
-        let font_str = format!("{font_size_px}px {font_family}");
+        let font_str = format!("{}px {}", font_config.size_px, font_config.family);
         ctx.set_font(&font_str);
         let metrics = ctx
             .measure_text("M")
             .map_err(|e| JsError::new(&format!("measureText failed: {e:?}")))?;
 
         let cell_width = metrics.width() as f32;
-        let cell_height = (font_size_px * 1.4_f32).ceil();
+        let cell_height = (font_config.size_px * font_config.line_height_multiplier).ceil();
 
         // Handle device pixel ratio for sharp text.
         let window = web_sys::window().ok_or_else(|| JsError::new("No window"))?;
@@ -59,7 +78,9 @@ impl Canvas2dRenderer {
         canvas.set_height((css_height as f64 * dpr) as u32);
 
         // Scale context for HiDPI.
-        let _ = ctx.scale(dpr, dpr);
+        if let Err(e) = ctx.scale(dpr, dpr) {
+            log::error!("Canvas scale failed: {e:?}");
+        }
 
         log::info!(
             "Canvas2D renderer: cell={cell_width}x{cell_height}, dpr={dpr}, canvas={css_width}x{css_height}"
@@ -68,8 +89,7 @@ impl Canvas2dRenderer {
         Ok(Self {
             canvas: canvas.clone(),
             ctx,
-            font_family,
-            font_size_px,
+            font_config,
             cell_width,
             cell_height,
             device_pixel_ratio: dpr,
@@ -84,7 +104,7 @@ impl Canvas2dRenderer {
         let num_lines = term.screen_lines();
 
         let bg_color = colors::default_named_color(NamedColor::Background);
-        let fg_default = colors::default_named_color(NamedColor::Foreground);
+        let _fg_default = colors::default_named_color(NamedColor::Foreground);
 
         let cw = self.cell_width as f64;
         let ch = self.cell_height as f64;
@@ -98,7 +118,9 @@ impl Canvas2dRenderer {
         if self.canvas.width() != needed_w || self.canvas.height() != needed_h {
             self.canvas.set_width(needed_w);
             self.canvas.set_height(needed_h);
-            let _ = self.ctx.scale(dpr, dpr);
+            if let Err(e) = self.ctx.scale(dpr, dpr) {
+                log::error!("Canvas scale failed during resize: {e:?}");
+            }
         }
 
         // Clear with background color.
@@ -110,7 +132,7 @@ impl Canvas2dRenderer {
             .fill_rect(0.0, 0.0, total_width + 10.0, total_height + 10.0);
 
         // Set font.
-        let font_str = format!("{}px {}", self.font_size_px, self.font_family);
+        let font_str = format!("{}px {}", self.font_config.size_px, self.font_config.family);
         self.ctx.set_font(&font_str);
         self.ctx.set_text_baseline("top");
 
@@ -162,8 +184,10 @@ impl Canvas2dRenderer {
             if is_bold != current_bold || is_italic != current_italic {
                 let weight = if is_bold { "bold " } else { "" };
                 let style = if is_italic { "italic " } else { "" };
-                let font_str =
-                    format!("{style}{weight}{}px {}", self.font_size_px, self.font_family);
+                let font_str = format!(
+                    "{style}{weight}{}px {}",
+                    self.font_config.size_px, self.font_config.family
+                );
                 self.ctx.set_font(&font_str);
                 current_bold = is_bold;
                 current_italic = is_italic;
@@ -175,7 +199,9 @@ impl Canvas2dRenderer {
                 cell_fg.r, cell_fg.g, cell_fg.b
             ));
             let ch_str = cell.c.to_string();
-            let _ = self.ctx.fill_text(&ch_str, x, y + 2.0);
+            if let Err(e) = self.ctx.fill_text(&ch_str, x, y + 2.0) {
+                log::error!("fill_text failed: {e:?}");
+            }
         }
 
         // Draw cursor.
@@ -198,6 +224,35 @@ impl Canvas2dRenderer {
     /// Cell height in pixels.
     pub fn cell_height(&self) -> f32 {
         self.cell_height
+    }
+
+    /// Set the font size and remeasure cell dimensions.
+    pub fn set_font_size(&mut self, size_px: f32) {
+        self.font_config.size_px = size_px;
+        self.remeasure_cells();
+    }
+
+    /// Set the font family and remeasure cell dimensions.
+    pub fn set_font_family(&mut self, family: &str) {
+        self.font_config.family = family.to_string();
+        self.remeasure_cells();
+    }
+
+    /// Set the line height multiplier and remeasure cell dimensions.
+    pub fn set_line_height_multiplier(&mut self, multiplier: f32) {
+        self.font_config.line_height_multiplier = multiplier;
+        self.remeasure_cells();
+    }
+
+    /// Remeasure cell dimensions after font config changes.
+    fn remeasure_cells(&mut self) {
+        let font_str = format!("{}px {}", self.font_config.size_px, self.font_config.family);
+        self.ctx.set_font(&font_str);
+        if let Ok(metrics) = self.ctx.measure_text("M") {
+            self.cell_width = metrics.width() as f32;
+            self.cell_height =
+                (self.font_config.size_px * self.font_config.line_height_multiplier).ceil();
+        }
     }
 
     /// Resize the canvas.

--- a/alacritty_web/src/renderer/glyph_cache.rs
+++ b/alacritty_web/src/renderer/glyph_cache.rs
@@ -198,7 +198,9 @@ impl GlyphCache {
 
         // Clear and draw.
         ctx.clear_rect(0.0, 0.0, glyph_w as f64, glyph_h as f64);
-        let _ = ctx.fill_text(&ch, 0.0, 0.0);
+        if let Err(e) = ctx.fill_text(&ch, 0.0, 0.0) {
+            log::error!("Glyph cache fill_text failed: {e:?}");
+        }
 
         // Read pixel data.
         let image_data = ctx

--- a/alacritty_web/src/websocket.rs
+++ b/alacritty_web/src/websocket.rs
@@ -5,6 +5,10 @@
 //! - 0x01 + 4x u16 LE (cols, rows, cell_w, cell_h) = resize (client->server)
 //! - 0x02 + optional exit code = child exited (server->client)
 
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::rc::Rc;
+
 use wasm_bindgen::prelude::*;
 use web_sys::{BinaryType, MessageEvent, WebSocket};
 
@@ -15,19 +19,51 @@ const MSG_CHILD_EXIT: u8 = 0x02;
 /// WebSocket connection to the PTY server.
 pub struct WsConnection {
     ws: WebSocket,
+    /// Whether the WebSocket connection is open and ready to send data.
+    open: Rc<RefCell<bool>>,
+    /// Messages queued before the connection was open.
+    pending: Rc<RefCell<VecDeque<Vec<u8>>>>,
+    _on_open: Closure<dyn FnMut(JsValue)>,
     _on_message: Closure<dyn FnMut(MessageEvent)>,
     _on_error: Closure<dyn FnMut(web_sys::ErrorEvent)>,
     _on_close: Closure<dyn FnMut(web_sys::CloseEvent)>,
 }
 
 impl WsConnection {
-    /// Create a new WebSocket connection with a callback for incoming PTY data.
-    pub fn new<F>(url: &str, on_pty_data: F) -> Result<Self, JsError>
+    /// Create a new WebSocket connection with callbacks for connection open and incoming PTY data.
+    pub fn new<F, G>(url: &str, on_open: G, on_pty_data: F) -> Result<Self, JsError>
     where
         F: Fn(&[u8]) + 'static,
+        G: FnOnce() + 'static,
     {
         let ws = WebSocket::new(url).map_err(|e| JsError::new(&format!("{e:?}")))?;
         ws.set_binary_type(BinaryType::Arraybuffer);
+
+        let open = Rc::new(RefCell::new(false));
+        let pending: Rc<RefCell<VecDeque<Vec<u8>>>> = Rc::new(RefCell::new(VecDeque::new()));
+
+        // onopen: mark as ready, flush pending messages, call user callback.
+        let open_flag = open.clone();
+        let pending_flush = pending.clone();
+        let ws_for_open = ws.clone();
+        let on_open_cell = RefCell::new(Some(on_open));
+        let on_open_closure = Closure::wrap(Box::new(move |_: JsValue| {
+            log::info!("WebSocket connection opened");
+            *open_flag.borrow_mut() = true;
+
+            // Flush any pending messages.
+            let mut queue = pending_flush.borrow_mut();
+            while let Some(msg) = queue.pop_front() {
+                if let Err(e) = ws_for_open.send_with_u8_array(&msg) {
+                    log::error!("WebSocket send error while flushing pending: {e:?}");
+                }
+            }
+
+            // Call the user's on_open callback (once).
+            if let Some(cb) = on_open_cell.borrow_mut().take() {
+                cb();
+            }
+        }) as Box<dyn FnMut(JsValue)>);
 
         let on_message = Closure::wrap(Box::new(move |event: MessageEvent| {
             if let Ok(buf) = event.data().dyn_into::<js_sys::ArrayBuffer>() {
@@ -42,13 +78,13 @@ impl WsConnection {
                         if data.len() > 1 {
                             on_pty_data(&data[1..]);
                         }
-                    },
+                    }
                     MSG_CHILD_EXIT => {
                         log::info!("Child process exited");
-                    },
+                    }
                     other => {
                         log::warn!("Unknown message type: {other}");
-                    },
+                    }
                 }
             }
         }) as Box<dyn FnMut(MessageEvent)>);
@@ -65,16 +101,35 @@ impl WsConnection {
             );
         }) as Box<dyn FnMut(web_sys::CloseEvent)>);
 
+        ws.set_onopen(Some(on_open_closure.as_ref().unchecked_ref()));
         ws.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
         ws.set_onerror(Some(on_error.as_ref().unchecked_ref()));
         ws.set_onclose(Some(on_close.as_ref().unchecked_ref()));
 
         Ok(Self {
             ws,
+            open,
+            pending,
+            _on_open: on_open_closure,
             _on_message: on_message,
             _on_error: on_error,
             _on_close: on_close,
         })
+    }
+
+    /// Send a raw binary message, queuing it if the socket is not yet open.
+    fn send_or_queue(&self, msg: Vec<u8>) {
+        if *self.open.borrow() {
+            if let Err(e) = self.ws.send_with_u8_array(&msg) {
+                log::error!("WebSocket send error: {e:?}");
+            }
+        } else {
+            log::warn!(
+                "WebSocket not yet open, queuing message ({} bytes)",
+                msg.len()
+            );
+            self.pending.borrow_mut().push_back(msg);
+        }
     }
 
     /// Send PTY data to the server.
@@ -82,7 +137,7 @@ impl WsConnection {
         let mut msg = Vec::with_capacity(1 + data.len());
         msg.push(MSG_PTY_DATA);
         msg.extend_from_slice(data);
-        let _ = self.ws.send_with_u8_array(&msg);
+        self.send_or_queue(msg);
     }
 
     /// Send a resize message to the server.
@@ -93,12 +148,14 @@ impl WsConnection {
         msg.extend_from_slice(&rows.to_le_bytes());
         msg.extend_from_slice(&cell_w.to_le_bytes());
         msg.extend_from_slice(&cell_h.to_le_bytes());
-        let _ = self.ws.send_with_u8_array(&msg);
+        self.send_or_queue(msg);
     }
 }
 
 impl Drop for WsConnection {
     fn drop(&mut self) {
-        let _ = self.ws.close();
+        if let Err(e) = self.ws.close() {
+            log::error!("WebSocket close error: {e:?}");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **CORS wildcard removed**: Replace `Access-Control-Allow-Origin: *` with origin validation. New `--allowed-origin` CLI flag (repeatable). Without it, only same-origin connections are accepted.
- **Resize input validation**: Clamp cols to 1-500, rows to 1-200. Log warning for out-of-range values.
- **WebSocket `onopen` handler**: `WsConnection::new()` now accepts an `on_open` callback. Messages sent before the socket opens are queued and flushed on connect.
- **Child process cleanup**: When WebSocket closes, the child process is explicitly killed via `Arc<Mutex<Child>>`.
- **Error logging**: All `let _ =` on PTY writes, WebSocket sends, canvas operations, and glyph cache draws replaced with proper error logging.
- **Workspace fix**: `alacritty_web` excluded from `default-members` so `cargo build` on desktop skips the WASM crate.
- **Font config struct**: Extracted `FontConfig` (family, size_px, line_height_multiplier) in `canvas2d.rs`. Exposed `set_font_size`, `set_font_family`, `set_line_height_multiplier` on the renderer and wasm_bindgen API.

## Test plan

- [x] `cargo check -p alacritty_pty_server` passes
- [x] `cargo check -p alacritty_web --target wasm32-unknown-unknown` passes
- [x] `cargo check -p alacritty` passes (no regression)
- [ ] Manual: start pty server without `--allowed-origin`, verify cross-origin WS connections are rejected
- [ ] Manual: start with `--allowed-origin http://localhost:8080`, verify that origin is accepted
- [ ] Manual: send resize with cols=9999, verify it's clamped to 500 and warning is logged
- [ ] Manual: close browser tab, verify child process is killed in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)