### PR TITLE
Security hardening and bug fixes for WASM port (v2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,13 @@ members = [
     "alacritty_pty_server",
     "alacritty_web",
 ]
+default-members = [
+    "alacritty",
+    "alacritty_terminal",
+    "alacritty_config",
+    "alacritty_config_derive",
+    "alacritty_pty_server",
+]
 resolver = "2"
 
 [workspace.package]

--- a/alacritty_pty_server/src/main.rs
+++ b/alacritty_pty_server/src/main.rs
@@ -41,6 +41,11 @@ pub struct Args {
     /// Idle timeout in seconds -- disconnect sessions with no input (default: 300).
     #[arg(long, default_value_t = 300)]
     idle_timeout: u64,
+
+    /// Allowed WebSocket Origin values (repeatable). If not set, only requests
+    /// with no Origin header (same-origin) are accepted.
+    #[arg(long = "allowed-origin")]
+    allowed_origins: Vec<String>,
 }
 
 impl Args {
@@ -119,6 +124,11 @@ async fn main() {
         .expect("Failed to bind TCP listener");
 
     info!("Alacritty PTY server listening on ws://{}", addr);
+    if args.allowed_origins.is_empty() {
+        info!("CORS: only same-origin requests (no Origin header) accepted");
+    } else {
+        info!("CORS: allowed origins: {:?}", args.allowed_origins);
+    }
     info!(
         "Max sessions: {}, Idle timeout: {}s",
         args.max_sessions, args.idle_timeout

--- a/alacritty_pty_server/src/protocol.rs
+++ b/alacritty_pty_server/src/protocol.rs
@@ -5,6 +5,8 @@
 /// - `0x01` + 4x u16 LE      = resize (client -> server): cols, rows, cell_w, cell_h
 /// - `0x02` + optional u8     = child exited (server -> client), with optional exit code
 
+use log::warn;
+
 pub const MSG_DATA: u8 = 0x00;
 pub const MSG_RESIZE: u8 = 0x01;
 pub const MSG_EXIT: u8 = 0x02;
@@ -36,10 +38,21 @@ pub fn parse_client_message(data: &[u8]) -> Option<ClientMessage> {
                 // Need 1 byte tag + 4 * 2 bytes = 9 bytes total.
                 return None;
             }
-            let cols = u16::from_le_bytes([data[1], data[2]]);
-            let rows = u16::from_le_bytes([data[3], data[4]]);
+            let raw_cols = u16::from_le_bytes([data[1], data[2]]);
+            let raw_rows = u16::from_le_bytes([data[3], data[4]]);
             let cell_w = u16::from_le_bytes([data[5], data[6]]);
             let cell_h = u16::from_le_bytes([data[7], data[8]]);
+
+            // Clamp cols to 1..=500 and rows to 1..=200 to prevent abuse.
+            let cols = raw_cols.clamp(1, 500);
+            let rows = raw_rows.clamp(1, 200);
+            if cols != raw_cols || rows != raw_rows {
+                warn!(
+                    "Resize values clamped: cols {}→{}, rows {}→{}",
+                    raw_cols, cols, raw_rows, rows
+                );
+            }
+
             Some(ClientMessage::Resize {
                 cols,
                 rows,

--- a/alacritty_pty_server/src/session.rs
+++ b/alacritty_pty_server/src/session.rs
@@ -23,15 +23,49 @@ pub async fn handle_connection(
     peer: SocketAddr,
     args: Arc<Args>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // WebSocket upgrade with CORS headers.
+    // WebSocket upgrade with CORS origin validation.
+    let allowed_origins = args.allowed_origins.clone();
     let ws_stream =
-        tokio_tungstenite::accept_hdr_async(stream, |req: &Request, mut resp: Response| {
-            // Add CORS header for the demo website.
-            resp.headers_mut().insert(
-                http::header::ACCESS_CONTROL_ALLOW_ORIGIN,
-                http::HeaderValue::from_static("*"),
-            );
-            let _ = req;
+        tokio_tungstenite::accept_hdr_async(stream, move |req: &Request, mut resp: Response| {
+            // Validate the Origin header.
+            let origin = req
+                .headers()
+                .get(http::header::ORIGIN)
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_string());
+
+            match (&origin, allowed_origins.is_empty()) {
+                // No Origin header and no allowed origins configured: same-origin, allow.
+                (None, true) => {},
+                // Origin present but no allowed origins configured: reject.
+                (Some(o), true) => {
+                    warn!("Rejecting connection with Origin '{}' (no allowed origins configured)", o);
+                    return Err(http::Response::builder()
+                        .status(http::StatusCode::FORBIDDEN)
+                        .body(Some("Origin not allowed".to_string()))
+                        .unwrap());
+                },
+                // Allowed origins configured: check if Origin matches.
+                (Some(o), false) => {
+                    if !allowed_origins.contains(o) {
+                        warn!("Rejecting connection with Origin '{}' (not in allowed list)", o);
+                        return Err(http::Response::builder()
+                            .status(http::StatusCode::FORBIDDEN)
+                            .body(Some("Origin not allowed".to_string()))
+                            .unwrap());
+                    }
+                },
+                // No Origin header but allowed origins configured: allow (e.g. non-browser client).
+                (None, false) => {},
+            }
+
+            if let Some(ref o) = origin {
+                if let Ok(val) = http::HeaderValue::from_str(o) {
+                    resp.headers_mut()
+                        .insert(http::header::ACCESS_CONTROL_ALLOW_ORIGIN, val);
+                }
+            }
+
             Ok(resp)
         })
         .await?;
@@ -54,7 +88,9 @@ pub async fn handle_connection(
 
                 if !valid {
                     warn!("Auth failed from {}: invalid token", peer);
-                    let _ = ws_sink.send(Message::Close(None)).await;
+                    if let Err(e) = ws_sink.send(Message::Close(None)).await {
+                        warn!("Failed to send close after auth failure: {}", e);
+                    }
                     return Ok(());
                 }
                 info!("Auth succeeded for {}", peer);
@@ -64,7 +100,9 @@ pub async fn handle_connection(
                     "Auth failed from {}: expected text message with token",
                     peer
                 );
-                let _ = ws_sink.send(Message::Close(None)).await;
+                if let Err(e) = ws_sink.send(Message::Close(None)).await {
+                    warn!("Failed to send close after auth failure: {}", e);
+                }
                 return Ok(());
             },
         }
@@ -87,7 +125,7 @@ pub async fn handle_connection(
     let mut cmd = CommandBuilder::new(&shell);
     cmd.env("TERM", "xterm-256color");
 
-    let mut child = pair
+    let child = pair
         .slave
         .spawn_command(cmd)
         .map_err(|e| format!("Failed to spawn shell '{}': {}", shell, e))?;
@@ -142,7 +180,9 @@ pub async fn handle_connection(
                 break;
             }
         }
-        let _ = ws_sink.close().await;
+        if let Err(e) = ws_sink.close().await {
+            warn!("Failed to close WebSocket sink: {}", e);
+        }
     });
 
     // Task 3: Read from WebSocket and write to PTY / handle resize.
@@ -179,11 +219,15 @@ pub async fn handle_connection(
                                         ClientMessage::Data(payload) => {
                                             last_input = Instant::now();
                                             let writer = Arc::clone(&writer);
-                                            let _ = tokio::task::spawn_blocking(move || {
+                                            if let Err(e) = tokio::task::spawn_blocking(move || {
                                                 let mut w = writer.lock().unwrap();
-                                                let _ = w.write_all(&payload);
+                                                if let Err(e) = w.write_all(&payload) {
+                                                    error!("PTY write error: {}", e);
+                                                }
                                             })
-                                            .await;
+                                            .await {
+                                                error!("PTY write task panicked: {}", e);
+                                            }
                                         },
                                         ClientMessage::Resize {
                                             cols,
@@ -194,7 +238,7 @@ pub async fn handle_connection(
                                             // Resize also counts as activity.
                                             last_input = Instant::now();
                                             let master = Arc::clone(&master);
-                                            let _ = tokio::task::spawn_blocking(move || {
+                                            if let Err(e) = tokio::task::spawn_blocking(move || {
                                                 let m = master.lock().unwrap();
                                                 let size = PtySize {
                                                     rows,
@@ -211,7 +255,9 @@ pub async fn handle_connection(
                                                     );
                                                 }
                                             })
-                                            .await;
+                                            .await {
+                                                error!("PTY resize task panicked: {}", e);
+                                            }
                                         },
                                     }
                                 }
@@ -239,10 +285,14 @@ pub async fn handle_connection(
         }
     });
 
+    // Wrap child in Arc<Mutex> so we can kill it on WebSocket close.
+    let child = Arc::new(std::sync::Mutex::new(child));
+
     // Task 4: Wait for child to exit and send exit notification.
     let ws_tx_exit = ws_tx.clone();
+    let child_for_wait = Arc::clone(&child);
     let child_wait_handle = tokio::task::spawn_blocking(move || {
-        let status = child.wait();
+        let status = child_for_wait.lock().unwrap().wait();
         let exit_code = match status {
             Ok(status) => {
                 if status.success() {
@@ -257,7 +307,9 @@ pub async fn handle_connection(
         };
         info!("Child exited with code: {:?}", exit_code);
         let msg = protocol::encode_exit(exit_code);
-        let _ = ws_tx_exit.blocking_send(Message::Binary(msg.into()));
+        if let Err(e) = ws_tx_exit.blocking_send(Message::Binary(msg.into())) {
+            warn!("Failed to send exit notification: {}", e);
+        }
     });
 
     // Wait for the child to exit or the WebSocket read to finish.
@@ -267,15 +319,28 @@ pub async fn handle_connection(
         }
         _ = ws_read_handle => {
             info!("WebSocket closed by client {}", peer);
+            // Kill the child process if still running.
+            if let Ok(mut child_guard) = child.lock() {
+                if let Err(e) = child_guard.kill() {
+                    // ESRCH (no such process) is expected if already exited.
+                    warn!("Failed to kill child process: {}", e);
+                } else {
+                    info!("Killed child process for disconnected client {}", peer);
+                }
+            }
         }
     }
 
     // Clean up: wait briefly for remaining data to flush.
-    let _ = pty_read_handle.await;
+    if let Err(e) = pty_read_handle.await {
+        error!("PTY read task panicked: {}", e);
+    }
 
     // Drop the sender so the write task finishes.
     drop(ws_tx);
-    let _ = ws_write_handle.await;
+    if let Err(e) = ws_write_handle.await {
+        error!("WebSocket write task panicked: {}", e);
+    }
 
     info!("Session ended for {}", peer);
     Ok(())

--- a/alacritty_web/src/lib.rs
+++ b/alacritty_web/src/lib.rs
@@ -189,7 +189,9 @@ impl AlacrittyTerminal {
             // Schedule next frame.
             if let Some(win) = web_sys::window() {
                 if let Some(cb) = callback_clone.borrow().as_ref() {
-                    let _ = win.request_animation_frame(cb.as_ref().unchecked_ref());
+                    if let Err(e) = win.request_animation_frame(cb.as_ref().unchecked_ref()) {
+                        log::warn!("request_animation_frame failed: {e:?}");
+                    }
                 }
             }
         }) as Box<dyn FnMut()>));

--- a/alacritty_web/src/renderer/canvas2d.rs
+++ b/alacritty_web/src/renderer/canvas2d.rs
@@ -14,12 +14,31 @@ use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
 use super::colors;
 use crate::terminal::WebEventProxy;
 
+/// Font configuration for the terminal renderer.
+#[derive(Clone, Debug)]
+pub struct FontConfig {
+    pub family: String,
+    pub size_px: f32,
+    pub line_height_multiplier: f32,
+}
+
+impl Default for FontConfig {
+    fn default() -> Self {
+        Self {
+            family: "'Fira Code', 'Cascadia Code', 'Source Code Pro', monospace".to_string(),
+            size_px: 14.0,
+            line_height_multiplier: 1.4,
+        }
+    }
+}
+
 /// Canvas 2D-based terminal renderer.
 pub struct Canvas2dRenderer {
     canvas: HtmlCanvasElement,
     ctx: CanvasRenderingContext2d,
     font_family: String,
     font_size_px: f32,
+    line_height_multiplier: f32,
     cell_width: f32,
     cell_height: f32,
     device_pixel_ratio: f64,
@@ -46,7 +65,8 @@ impl Canvas2dRenderer {
             .map_err(|e| JsError::new(&format!("measureText failed: {e:?}")))?;
 
         let cell_width = metrics.width() as f32;
-        let cell_height = (font_size_px * 1.4_f32).ceil();
+        let line_height_multiplier = 1.4_f32;
+        let cell_height = (font_size_px * line_height_multiplier).ceil();
 
         // Handle device pixel ratio for sharp text.
         let window = web_sys::window().ok_or_else(|| JsError::new("No window"))?;
@@ -59,7 +79,9 @@ impl Canvas2dRenderer {
         canvas.set_height((css_height as f64 * dpr) as u32);
 
         // Scale context for HiDPI.
-        let _ = ctx.scale(dpr, dpr);
+        if let Err(e) = ctx.scale(dpr, dpr) {
+            log::warn!("Canvas scale failed: {e:?}");
+        }
 
         log::info!(
             "Canvas2D renderer: cell={cell_width}x{cell_height}, dpr={dpr}, canvas={css_width}x{css_height}"
@@ -70,6 +92,7 @@ impl Canvas2dRenderer {
             ctx,
             font_family,
             font_size_px,
+            line_height_multiplier,
             cell_width,
             cell_height,
             device_pixel_ratio: dpr,
@@ -98,7 +121,9 @@ impl Canvas2dRenderer {
         if self.canvas.width() != needed_w || self.canvas.height() != needed_h {
             self.canvas.set_width(needed_w);
             self.canvas.set_height(needed_h);
-            let _ = self.ctx.scale(dpr, dpr);
+            if let Err(e) = self.ctx.scale(dpr, dpr) {
+                log::warn!("Canvas scale failed: {e:?}");
+            }
         }
 
         // Clear with background color.
@@ -175,7 +200,9 @@ impl Canvas2dRenderer {
                 cell_fg.r, cell_fg.g, cell_fg.b
             ));
             let ch_str = cell.c.to_string();
-            let _ = self.ctx.fill_text(&ch_str, x, y + 2.0);
+            if let Err(e) = self.ctx.fill_text(&ch_str, x, y + 2.0) {
+                log::warn!("Canvas fill_text failed: {e:?}");
+            }
         }
 
         // Draw cursor.
@@ -212,13 +239,19 @@ impl Canvas2dRenderer {
         self.remeasure_cells();
     }
 
+    /// Set the line height multiplier and remeasure cell dimensions.
+    pub fn set_line_height_multiplier(&mut self, multiplier: f32) {
+        self.line_height_multiplier = multiplier;
+        self.remeasure_cells();
+    }
+
     /// Remeasure cell dimensions after font changes.
     fn remeasure_cells(&mut self) {
         let font_str = format!("{}px {}", self.font_size_px, self.font_family);
         self.ctx.set_font(&font_str);
         if let Ok(metrics) = self.ctx.measure_text("M") {
             self.cell_width = metrics.width() as f32;
-            self.cell_height = (self.font_size_px * 1.4_f32).ceil();
+            self.cell_height = (self.font_size_px * self.line_height_multiplier).ceil();
         }
     }
 

--- a/alacritty_web/src/renderer/glyph_cache.rs
+++ b/alacritty_web/src/renderer/glyph_cache.rs
@@ -198,7 +198,9 @@ impl GlyphCache {
 
         // Clear and draw.
         ctx.clear_rect(0.0, 0.0, glyph_w as f64, glyph_h as f64);
-        let _ = ctx.fill_text(&ch, 0.0, 0.0);
+        if let Err(e) = ctx.fill_text(&ch, 0.0, 0.0) {
+            log::warn!("Glyph rasterize fill_text failed: {e:?}");
+        }
 
         // Read pixel data.
         let image_data = ctx


### PR DESCRIPTION
## Summary

Re-applies the non-overlapping security and bug fixes from #31 (PR #36 was closed due to conflicts) on a clean branch off `wasm`, avoiding duplication with auth hardening already merged in #35.

- **CORS origin validation**: New `--allowed-origin` CLI flag (repeatable) on the PTY server. When no origins are configured, only requests without an `Origin` header (same-origin) are accepted. Cross-origin requests are rejected with 403.
- **Resize input validation**: Clamps cols to 1..=500 and rows to 1..=200 in the binary protocol parser, logging a warning when values are out of range.
- **Child process cleanup**: When the WebSocket connection closes before the child exits, the child process is explicitly killed to prevent orphaned processes.
- **Workspace `default-members`**: Excludes `alacritty_web` from default `cargo build` so desktop builds don't require `wasm32-unknown-unknown` target.
- **Replace `let _ =` with error logging**: Across `session.rs`, `canvas2d.rs`, `glyph_cache.rs`, and `lib.rs` — fallible operations now log errors instead of silently discarding them.
- **Fix pre-existing compile errors**: Added missing `FontConfig` struct and `set_line_height_multiplier` method to the Canvas2D renderer (referenced in `lib.rs` but not defined).

## Notes

- WebSocket `onopen` handler with message queuing was already implemented in the current codebase, so no changes were needed there.
- Auth hardening (constant-time token comparison, rate limiting, max sessions, idle timeout, shell validation) from #35 was not duplicated.

## Test plan

- [ ] `cargo check -p alacritty_pty_server` passes
- [ ] `cargo check -p alacritty_web --target wasm32-unknown-unknown` passes
- [ ] `cargo check -p alacritty` passes
- [ ] Verify CORS rejection: connect from disallowed origin with `--allowed-origin` set
- [ ] Verify resize clamping: send resize with cols=10000, rows=10000 and check logs
- [ ] Verify child cleanup: disconnect WebSocket and confirm child process is killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)